### PR TITLE
Add hyphenation to "multi-column"

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -32,7 +32,7 @@ urlPrefix: https://www.w3.org/TR/SVG2/#InterfaceSVGGraphicsElement
     urlPrefix: types.html
         url: #InterfaceSVGGraphicsElement; type: dfn; text: SVGGraphicsElement
 urlPrefix: https://www.w3.org/TR/css3-multicol/
-    url: #; type: dfn; text: Multi column
+    url: #; type: dfn; text: Multi-column
 
 </pre>
 <pre class=link-defaults>
@@ -295,7 +295,7 @@ DOM <dfn>content rect</dfn> is a rect whose:
 * top is <a>padding top</a>
 * left is <a>padding left</a>
 
-<a>content width</a> spec does not mention how <a>multi column</a> layout affects content box. In this spec, content width of an {{Element}} inside <a>multi column</a> is the result of getComputedStyle({{Element}}).width. This currently evaluates to width of the first column.
+<a>content width</a> spec does not mention how <a>multi-column</a> layout affects content box. In this spec, content width of an {{Element}} inside <a>multi-column</a> is the result of getComputedStyle({{Element}}).width. This currently evaluates to width of the first column.
 
 Having content rect position be padding-top/left is useful for absolute positioning of target's children. Absolute position coordinate space origin is topLeft of the padding rect.
 


### PR DESCRIPTION
The multi-column spec uses a hyphen ("multi-column", not "multi column").  We should use that same spelling here.

I believe this change should fix that in the Bikeshed source -- I simply added a hyphen to every instance of the term "multi column".
