### PR TITLE
Give `<img>` a valid `src` attribute in test

### DIFF
--- a/test/observe.html
+++ b/test/observe.html
@@ -5,7 +5,8 @@
 <p>ResizeObserver tests</p>
 <div id="target1" style="width:100px;height:100px;">t1</div>
 <div id="target2" style="width:100px;height:100px;">t2</div>
-<img id="target3" style="width:100px;height:100px;">
+<img id="target3" style="width:100px;height:100px;"
+     src="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg'/>">
 <iframe src="./resources/iframe.html" width="300px" height="100px" style="display:block"></iframe>
 <script>
 'use strict';


### PR DESCRIPTION
This adds a valid `src` attribute (for a data URI that encodes an empty SVG document) to make the `<img>` definitely a replaced element, across browsers.  (so that its behavior RE "should it fire resize observations" will be well-defined)

This addresses #23.
