### PR TITLE
Add chat window example

### DIFF
--- a/examples/chat/README.md
+++ b/examples/chat/README.md
@@ -1,0 +1,1 @@
+The `chat` example shows how a few lines of JavaScript with `ResizeObserver` are enough to keep a window scrolled to the bottom, as you’d expect from a chat conversation. It reacts to window resizes and new messages being appended.

--- a/examples/chat/index.html
+++ b/examples/chat/index.html
@@ -1,0 +1,53 @@
+<!doctype html>
+<meta encoding="utf-8">
+<meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
+
+<style>
+	#chatTab {
+		width: 200px;
+		border: 1px solid green;
+		margin: 0 auto;
+	}
+	.content {
+		background-color: lightgreen;
+		border: 1px solid black;
+	}
+	button {
+		position: fixed;
+		top: 0;
+		font-size: 2em;
+		border: 1px solid black;
+	}
+	.add {
+		left: 0;
+	}
+	.remove {
+		right: 0;
+	}
+</style>
+<div id="chatTab">
+</div>
+<button class="add">add</button>
+<button class="remove">remove</button>
+<script>
+const chatTab = document.querySelector('#chatTab');
+let messageId = 0;
+
+document.querySelector('.add').addEventListener('click', _ => {
+	const el = document.createElement('div');
+	el.classList.add('content');
+	el.innerText = "message" + messageId++;
+	el.style.height = Math.floor(30+Math.random()*100) + 'px';
+	chatTab.appendChild(el);
+});
+
+document.querySelector('.remove').addEventListener('click', _ => {
+	chatTab.removeChild(chatTab.lastChild);
+});
+
+const ro = new ResizeObserver(entries => {
+	document.scrollingElement.scrollTop = document.scrollingElement.scrollHeight;
+});
+ro.observe(chatTab);
+ro.observe(document.scrollingElement);
+</script>


### PR DESCRIPTION
From the README:

The `chat` example shows how a few lines of JavaScript with `ResizeObserver` are enough to keep a window scrolled to the bottom, as you’d expect from a chat conversation. It reacts to window resizes, new messages being appended and images loading in after some delay.

All the relevant code is in the `index.html`. `messages.js` and `messages.css` are for polish and randomized message generation.
