### PR TITLE
Update generated spec to match latest source

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,255 +5,256 @@
   <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport">
   <meta content="ED" name="w3c-status">
   <link href="https://www.w3.org/StyleSheets/TR/2016/W3C-ED" rel="stylesheet" type="text/css">
-  <meta content="Bikeshed version fa6d32dea6b39d19cbb9dd6d5e69f189e8bdd53f" name="generator">
+  <meta content="Bikeshed version 1a927b7d2ff9a70dcdc5dc9f892fd154b7b64097" name="generator">
+  <link href="https://github.com/WICG/ResizeObserver/" rel="canonical">
 <style>/* style-md-lists */
 
-            /* This is a weird hack for me not yet following the commonmark spec
-               regarding paragraph and lists. */
-            [data-md] > :first-child {
-                margin-top: 0;
-            }
-            [data-md] > :last-child {
-                margin-bottom: 0;
-            }</style>
+/* This is a weird hack for me not yet following the commonmark spec
+   regarding paragraph and lists. */
+[data-md] > :first-child {
+    margin-top: 0;
+}
+[data-md] > :last-child {
+    margin-bottom: 0;
+}</style>
 <style>/* style-selflinks */
 
-            .heading, .issue, .note, .example, li, dt {
-                position: relative;
-            }
-            a.self-link {
-                position: absolute;
-                top: 0;
-                left: calc(-1 * (3.5rem - 26px));
-                width: calc(3.5rem - 26px);
-                height: 2em;
-                text-align: center;
-                border: none;
-                transition: opacity .2s;
-                opacity: .5;
-            }
-            a.self-link:hover {
-                opacity: 1;
-            }
-            .heading > a.self-link {
-                font-size: 83%;
-            }
-            li > a.self-link {
-                left: calc(-1 * (3.5rem - 26px) - 2em);
-            }
-            dfn > a.self-link {
-                top: auto;
-                left: auto;
-                opacity: 0;
-                width: 1.5em;
-                height: 1.5em;
-                background: gray;
-                color: white;
-                font-style: normal;
-                transition: opacity .2s, background-color .2s, color .2s;
-            }
-            dfn:hover > a.self-link {
-                opacity: 1;
-            }
-            dfn > a.self-link:hover {
-                color: black;
-            }
+.heading, .issue, .note, .example, li, dt {
+    position: relative;
+}
+a.self-link {
+    position: absolute;
+    top: 0;
+    left: calc(-1 * (3.5rem - 26px));
+    width: calc(3.5rem - 26px);
+    height: 2em;
+    text-align: center;
+    border: none;
+    transition: opacity .2s;
+    opacity: .5;
+}
+a.self-link:hover {
+    opacity: 1;
+}
+.heading > a.self-link {
+    font-size: 83%;
+}
+li > a.self-link {
+    left: calc(-1 * (3.5rem - 26px) - 2em);
+}
+dfn > a.self-link {
+    top: auto;
+    left: auto;
+    opacity: 0;
+    width: 1.5em;
+    height: 1.5em;
+    background: gray;
+    color: white;
+    font-style: normal;
+    transition: opacity .2s, background-color .2s, color .2s;
+}
+dfn:hover > a.self-link {
+    opacity: 1;
+}
+dfn > a.self-link:hover {
+    color: black;
+}
 
-            a.self-link::before            { content: "¶"; }
-            .heading > a.self-link::before { content: "§"; }
-            dfn > a.self-link::before      { content: "#"; }</style>
+a.self-link::before            { content: "¶"; }
+.heading > a.self-link::before { content: "§"; }
+dfn > a.self-link::before      { content: "#"; }</style>
 <style>/* style-counters */
 
-            body {
-                counter-reset: example figure issue;
-            }
-            .issue {
-                counter-increment: issue;
-            }
-            .issue:not(.no-marker)::before {
-                content: "Issue " counter(issue);
-            }
+body {
+    counter-reset: example figure issue;
+}
+.issue {
+    counter-increment: issue;
+}
+.issue:not(.no-marker)::before {
+    content: "Issue " counter(issue);
+}
 
-            .example {
-                counter-increment: example;
-            }
-            .example:not(.no-marker)::before {
-                content: "Example " counter(example);
-            }
-            .invalid.example:not(.no-marker)::before,
-            .illegal.example:not(.no-marker)::before {
-                content: "Invalid Example" counter(example);
-            }
+.example {
+    counter-increment: example;
+}
+.example:not(.no-marker)::before {
+    content: "Example " counter(example);
+}
+.invalid.example:not(.no-marker)::before,
+.illegal.example:not(.no-marker)::before {
+    content: "Invalid Example" counter(example);
+}
 
-            figcaption {
-                counter-increment: figure;
-            }
-            figcaption:not(.no-marker)::before {
-                content: "Figure " counter(figure) " ";
-            }</style>
+figcaption {
+    counter-increment: figure;
+}
+figcaption:not(.no-marker)::before {
+    content: "Figure " counter(figure) " ";
+}</style>
 <style>/* style-autolinks */
 
-            .css.css, .property.property, .descriptor.descriptor {
-                color: #005a9c;
-                font-size: inherit;
-                font-family: inherit;
-            }
-            .css::before, .property::before, .descriptor::before {
-                content: "‘";
-            }
-            .css::after, .property::after, .descriptor::after {
-                content: "’";
-            }
-            .property, .descriptor {
-                /* Don't wrap property and descriptor names */
-                white-space: nowrap;
-            }
-            .type { /* CSS value <type> */
-                font-style: italic;
-            }
-            pre .property::before, pre .property::after {
-                content: "";
-            }
-            [data-link-type="property"]::before,
-            [data-link-type="propdesc"]::before,
-            [data-link-type="descriptor"]::before,
-            [data-link-type="value"]::before,
-            [data-link-type="function"]::before,
-            [data-link-type="at-rule"]::before,
-            [data-link-type="selector"]::before,
-            [data-link-type="maybe"]::before {
-                content: "‘";
-            }
-            [data-link-type="property"]::after,
-            [data-link-type="propdesc"]::after,
-            [data-link-type="descriptor"]::after,
-            [data-link-type="value"]::after,
-            [data-link-type="function"]::after,
-            [data-link-type="at-rule"]::after,
-            [data-link-type="selector"]::after,
-            [data-link-type="maybe"]::after {
-                content: "’";
-            }
+.css.css, .property.property, .descriptor.descriptor {
+    color: #005a9c;
+    font-size: inherit;
+    font-family: inherit;
+}
+.css::before, .property::before, .descriptor::before {
+    content: "‘";
+}
+.css::after, .property::after, .descriptor::after {
+    content: "’";
+}
+.property, .descriptor {
+    /* Don't wrap property and descriptor names */
+    white-space: nowrap;
+}
+.type { /* CSS value <type> */
+    font-style: italic;
+}
+pre .property::before, pre .property::after {
+    content: "";
+}
+[data-link-type="property"]::before,
+[data-link-type="propdesc"]::before,
+[data-link-type="descriptor"]::before,
+[data-link-type="value"]::before,
+[data-link-type="function"]::before,
+[data-link-type="at-rule"]::before,
+[data-link-type="selector"]::before,
+[data-link-type="maybe"]::before {
+    content: "‘";
+}
+[data-link-type="property"]::after,
+[data-link-type="propdesc"]::after,
+[data-link-type="descriptor"]::after,
+[data-link-type="value"]::after,
+[data-link-type="function"]::after,
+[data-link-type="at-rule"]::after,
+[data-link-type="selector"]::after,
+[data-link-type="maybe"]::after {
+    content: "’";
+}
 
-            [data-link-type].production::before,
-            [data-link-type].production::after,
-            .prod [data-link-type]::before,
-            .prod [data-link-type]::after {
-                content: "";
-            }
+[data-link-type].production::before,
+[data-link-type].production::after,
+.prod [data-link-type]::before,
+.prod [data-link-type]::after {
+    content: "";
+}
 
-            [data-link-type=element],
-            [data-link-type=element-attr] {
-                font-family: Menlo, Consolas, "DejaVu Sans Mono", monospace;
-                font-size: .9em;
-            }
-            [data-link-type=element]::before { content: "<" }
-            [data-link-type=element]::after  { content: ">" }
+[data-link-type=element],
+[data-link-type=element-attr] {
+    font-family: Menlo, Consolas, "DejaVu Sans Mono", monospace;
+    font-size: .9em;
+}
+[data-link-type=element]::before { content: "<" }
+[data-link-type=element]::after  { content: ">" }
 
-            [data-link-type=biblio] {
-                white-space: pre;
-            }</style>
+[data-link-type=biblio] {
+    white-space: pre;
+}</style>
 <style>/* style-dfn-panel */
 
-        .dfn-panel {
-            position: absolute;
-            z-index: 35;
-            height: auto;
-            width: -webkit-fit-content;
-            width: fit-content;
-            max-width: 300px;
-            max-height: 500px;
-            overflow: auto;
-            padding: 0.5em 0.75em;
-            font: small Helvetica Neue, sans-serif, Droid Sans Fallback;
-            background: #DDDDDD;
-            color: black;
-            border: outset 0.2em;
-        }
-        .dfn-panel:not(.on) { display: none; }
-        .dfn-panel * { margin: 0; padding: 0; text-indent: 0; }
-        .dfn-panel > b { display: block; }
-        .dfn-panel a { color: black; }
-        .dfn-panel a:not(:hover) { text-decoration: none !important; border-bottom: none !important; }
-        .dfn-panel > b + b { margin-top: 0.25em; }
-        .dfn-panel ul { padding: 0; }
-        .dfn-panel li { list-style: inside; }
-        .dfn-panel.activated {
-            display: inline-block;
-            position: fixed;
-            left: .5em;
-            bottom: 2em;
-            margin: 0 auto;
-            max-width: calc(100vw - 1.5em - .4em - .5em);
-            max-height: 30vh;
-        }
+.dfn-panel {
+    position: absolute;
+    z-index: 35;
+    height: auto;
+    width: -webkit-fit-content;
+    width: fit-content;
+    max-width: 300px;
+    max-height: 500px;
+    overflow: auto;
+    padding: 0.5em 0.75em;
+    font: small Helvetica Neue, sans-serif, Droid Sans Fallback;
+    background: #DDDDDD;
+    color: black;
+    border: outset 0.2em;
+}
+.dfn-panel:not(.on) { display: none; }
+.dfn-panel * { margin: 0; padding: 0; text-indent: 0; }
+.dfn-panel > b { display: block; }
+.dfn-panel a { color: black; }
+.dfn-panel a:not(:hover) { text-decoration: none !important; border-bottom: none !important; }
+.dfn-panel > b + b { margin-top: 0.25em; }
+.dfn-panel ul { padding: 0; }
+.dfn-panel li { list-style: inside; }
+.dfn-panel.activated {
+    display: inline-block;
+    position: fixed;
+    left: .5em;
+    bottom: 2em;
+    margin: 0 auto;
+    max-width: calc(100vw - 1.5em - .4em - .5em);
+    max-height: 30vh;
+}
 
-        .dfn-paneled { cursor: pointer; }
-        </style>
+.dfn-paneled { cursor: pointer; }
+</style>
 <style>/* style-syntax-highlighting */
 pre.idl.highlight { color: #708090; }
-        .highlight:not(.idl) { background: hsl(24, 20%, 95%); }
-        code.highlight { padding: .1em; border-radius: .3em; }
-        pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em 0; overflow: auto; border-radius: 0; }
-        .highlight .c { color: #708090 } /* Comment */
-        .highlight .k { color: #990055 } /* Keyword */
-        .highlight .l { color: #000000 } /* Literal */
-        .highlight .n { color: #0077aa } /* Name */
-        .highlight .o { color: #999999 } /* Operator */
-        .highlight .p { color: #999999 } /* Punctuation */
-        .highlight .cm { color: #708090 } /* Comment.Multiline */
-        .highlight .cp { color: #708090 } /* Comment.Preproc */
-        .highlight .c1 { color: #708090 } /* Comment.Single */
-        .highlight .cs { color: #708090 } /* Comment.Special */
-        .highlight .kc { color: #990055 } /* Keyword.Constant */
-        .highlight .kd { color: #990055 } /* Keyword.Declaration */
-        .highlight .kn { color: #990055 } /* Keyword.Namespace */
-        .highlight .kp { color: #990055 } /* Keyword.Pseudo */
-        .highlight .kr { color: #990055 } /* Keyword.Reserved */
-        .highlight .kt { color: #990055 } /* Keyword.Type */
-        .highlight .ld { color: #000000 } /* Literal.Date */
-        .highlight .m { color: #000000 } /* Literal.Number */
-        .highlight .s { color: #a67f59 } /* Literal.String */
-        .highlight .na { color: #0077aa } /* Name.Attribute */
-        .highlight .nc { color: #0077aa } /* Name.Class */
-        .highlight .no { color: #0077aa } /* Name.Constant */
-        .highlight .nd { color: #0077aa } /* Name.Decorator */
-        .highlight .ni { color: #0077aa } /* Name.Entity */
-        .highlight .ne { color: #0077aa } /* Name.Exception */
-        .highlight .nf { color: #0077aa } /* Name.Function */
-        .highlight .nl { color: #0077aa } /* Name.Label */
-        .highlight .nn { color: #0077aa } /* Name.Namespace */
-        .highlight .py { color: #0077aa } /* Name.Property */
-        .highlight .nt { color: #669900 } /* Name.Tag */
-        .highlight .nv { color: #222222 } /* Name.Variable */
-        .highlight .ow { color: #999999 } /* Operator.Word */
-        .highlight .mb { color: #000000 } /* Literal.Number.Bin */
-        .highlight .mf { color: #000000 } /* Literal.Number.Float */
-        .highlight .mh { color: #000000 } /* Literal.Number.Hex */
-        .highlight .mi { color: #000000 } /* Literal.Number.Integer */
-        .highlight .mo { color: #000000 } /* Literal.Number.Oct */
-        .highlight .sb { color: #a67f59 } /* Literal.String.Backtick */
-        .highlight .sc { color: #a67f59 } /* Literal.String.Char */
-        .highlight .sd { color: #a67f59 } /* Literal.String.Doc */
-        .highlight .s2 { color: #a67f59 } /* Literal.String.Double */
-        .highlight .se { color: #a67f59 } /* Literal.String.Escape */
-        .highlight .sh { color: #a67f59 } /* Literal.String.Heredoc */
-        .highlight .si { color: #a67f59 } /* Literal.String.Interpol */
-        .highlight .sx { color: #a67f59 } /* Literal.String.Other */
-        .highlight .sr { color: #a67f59 } /* Literal.String.Regex */
-        .highlight .s1 { color: #a67f59 } /* Literal.String.Single */
-        .highlight .ss { color: #a67f59 } /* Literal.String.Symbol */
-        .highlight .vc { color: #0077aa } /* Name.Variable.Class */
-        .highlight .vg { color: #0077aa } /* Name.Variable.Global */
-        .highlight .vi { color: #0077aa } /* Name.Variable.Instance */
-        .highlight .il { color: #000000 } /* Literal.Number.Integer.Long */
-        </style>
+.highlight:not(.idl) { background: hsl(24, 20%, 95%); }
+code.highlight { padding: .1em; border-radius: .3em; }
+pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em 0; overflow: auto; border-radius: 0; }
+.highlight .c { color: #708090 } /* Comment */
+.highlight .k { color: #990055 } /* Keyword */
+.highlight .l { color: #000000 } /* Literal */
+.highlight .n { color: #0077aa } /* Name */
+.highlight .o { color: #999999 } /* Operator */
+.highlight .p { color: #999999 } /* Punctuation */
+.highlight .cm { color: #708090 } /* Comment.Multiline */
+.highlight .cp { color: #708090 } /* Comment.Preproc */
+.highlight .c1 { color: #708090 } /* Comment.Single */
+.highlight .cs { color: #708090 } /* Comment.Special */
+.highlight .kc { color: #990055 } /* Keyword.Constant */
+.highlight .kd { color: #990055 } /* Keyword.Declaration */
+.highlight .kn { color: #990055 } /* Keyword.Namespace */
+.highlight .kp { color: #990055 } /* Keyword.Pseudo */
+.highlight .kr { color: #990055 } /* Keyword.Reserved */
+.highlight .kt { color: #990055 } /* Keyword.Type */
+.highlight .ld { color: #000000 } /* Literal.Date */
+.highlight .m { color: #000000 } /* Literal.Number */
+.highlight .s { color: #a67f59 } /* Literal.String */
+.highlight .na { color: #0077aa } /* Name.Attribute */
+.highlight .nc { color: #0077aa } /* Name.Class */
+.highlight .no { color: #0077aa } /* Name.Constant */
+.highlight .nd { color: #0077aa } /* Name.Decorator */
+.highlight .ni { color: #0077aa } /* Name.Entity */
+.highlight .ne { color: #0077aa } /* Name.Exception */
+.highlight .nf { color: #0077aa } /* Name.Function */
+.highlight .nl { color: #0077aa } /* Name.Label */
+.highlight .nn { color: #0077aa } /* Name.Namespace */
+.highlight .py { color: #0077aa } /* Name.Property */
+.highlight .nt { color: #669900 } /* Name.Tag */
+.highlight .nv { color: #222222 } /* Name.Variable */
+.highlight .ow { color: #999999 } /* Operator.Word */
+.highlight .mb { color: #000000 } /* Literal.Number.Bin */
+.highlight .mf { color: #000000 } /* Literal.Number.Float */
+.highlight .mh { color: #000000 } /* Literal.Number.Hex */
+.highlight .mi { color: #000000 } /* Literal.Number.Integer */
+.highlight .mo { color: #000000 } /* Literal.Number.Oct */
+.highlight .sb { color: #a67f59 } /* Literal.String.Backtick */
+.highlight .sc { color: #a67f59 } /* Literal.String.Char */
+.highlight .sd { color: #a67f59 } /* Literal.String.Doc */
+.highlight .s2 { color: #a67f59 } /* Literal.String.Double */
+.highlight .se { color: #a67f59 } /* Literal.String.Escape */
+.highlight .sh { color: #a67f59 } /* Literal.String.Heredoc */
+.highlight .si { color: #a67f59 } /* Literal.String.Interpol */
+.highlight .sx { color: #a67f59 } /* Literal.String.Other */
+.highlight .sr { color: #a67f59 } /* Literal.String.Regex */
+.highlight .s1 { color: #a67f59 } /* Literal.String.Single */
+.highlight .ss { color: #a67f59 } /* Literal.String.Symbol */
+.highlight .vc { color: #0077aa } /* Name.Variable.Class */
+.highlight .vg { color: #0077aa } /* Name.Variable.Global */
+.highlight .vi { color: #0077aa } /* Name.Variable.Instance */
+.highlight .il { color: #000000 } /* Literal.Number.Integer.Long */
+</style>
  <body class="h-entry">
   <div class="head">
    <header>
     <p data-fill-with="logo"><a href="https://www.w3.org/"><img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"></a> </p>
     <h1 class="p-name no-ref" id="title">Resize Observer 1</h1>
-    <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2017-03-20">20 March 2017</time></span></h2>
+    <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2018-05-27">27 May 2018</time></span></h2>
    </header>
    <div data-fill-with="spec-metadata">
     <dl>
@@ -264,34 +265,24 @@ pre.idl.highlight { color: #708090; }
     </dl>
    </div>
    <div data-fill-with="warning"></div>
-   <p class="copyright" data-fill-with="copyright"><a href="http://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © 2017 <a href="http://www.w3.org/"><abbr title="World Wide Web Consortium">W3C</abbr></a><sup>®</sup> (<a href="http://www.csail.mit.edu/"><abbr title="Massachusetts Institute of Technology">MIT</abbr></a>, <a href="http://www.ercim.eu/"><abbr title="European Research Consortium for Informatics and Mathematics">ERCIM</abbr></a>, <a href="http://www.keio.ac.jp/">Keio</a>, <a href="http://ev.buaa.edu.cn/">Beihang</a>). W3C <a href="http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>, <a href="http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and <a href="http://www.w3.org/Consortium/Legal/copyright-documents">document use</a> rules apply. </p>
+   <p class="copyright" data-fill-with="copyright"><a href="http://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © 2018 <a href="http://www.w3.org/"><abbr title="World Wide Web Consortium">W3C</abbr></a><sup>®</sup> (<a href="http://www.csail.mit.edu/"><abbr title="Massachusetts Institute of Technology">MIT</abbr></a>, <a href="http://www.ercim.eu/"><abbr title="European Research Consortium for Informatics and Mathematics">ERCIM</abbr></a>, <a href="http://www.keio.ac.jp/">Keio</a>, <a href="http://ev.buaa.edu.cn/">Beihang</a>). W3C <a href="http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>, <a href="http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and <a href="http://www.w3.org/Consortium/Legal/copyright-documents">document use</a> rules apply. </p>
    <hr title="Separator for header">
   </div>
-  <h2 class="no-num no-toc no-ref heading settled" id="abstract"><span class="content">Abstract</span></h2>
   <div class="p-summary" data-fill-with="abstract">
+   <h2 class="no-num no-toc no-ref heading settled" id="abstract"><span class="content">Abstract</span></h2>
    <p>This specification describes an API for observing changes to Element’s size.</p>
   </div>
   <h2 class="no-num no-toc no-ref heading settled" id="status"><span class="content">Status of this document</span></h2>
   <div data-fill-with="status">
-   <p> <em>This section describes the status of this document at the time of its publication. Other
-    documents may supersede this document. A list of current <abbr title="World Wide Web Consortium">W3C</abbr> publications and the latest revision of this
-    technical report can be found in the <a href="http://www.w3.org/TR/"><abbr title="World Wide Web Consortium">W3C</abbr> technical
-    reports index</a> at http://www.w3.org/TR/.</em> </p>
-   <p> This document was published by the <a href="http://www.w3.org/2010/webperf/">Web Performance Working Group</a> as an Editors Draft. This document is intended to become a W3C Recommendation.
-
-    Feedback and comments on this specification are welcome. Please use <a href="https://github.com/w3c/reporting/issues">Github issues</a>.
-    Discussions may also be found in the <a href="http://lists.w3.org/Archives/Public/public-web-perf/">public-web-perf@w3.org archives</a>. </p>
+   <p> <em>This section describes the status of this document at the time of its publication. Other documents may supersede this document. A list of current <abbr title="World Wide Web Consortium">W3C</abbr> publications and the latest revision of this technical report can be found in the <a href="https://www.w3.org/TR/"><abbr title="World Wide Web Consortium">W3C</abbr> technical reports index</a> at https://www.w3.org/TR/.</em> </p>
+   <p> This document was published by the <a href="https://www.w3.org/webperf/">Web Performance Working Group</a> as an Editors Draft. This document is intended to become a W3C Recommendation. </p>
+   <p></p>
+   <p> Feedback and comments on this specification are welcome, please send them to <a href="mailto:public-web-perf@w3.org?subject=%5Bresize-observer%5D">public-web-perf@w3.org</a> (<a href="mailto:public-web-perf-request@w3.org?subject=subscribe">subscribe</a>, <a href="https://lists.w3.org/Archives/Public/public-web-perf/">archives</a>) with <code>%5Bresize-observer%5D</code> at the start of your email’s subject. </p>
    <p> Publication as an Editors Draft does not imply endorsement by the <abbr title="World Wide Web Consortium">W3C</abbr> Membership. This is a draft document and may
     be updated, replaced or obsoleted by other documents at any time. It is inappropriate to cite
     this document as other than work in progress. </p>
-   <p> This document was produced by a group operating under the <a href="http://www.w3.org/Consortium/Patent-Policy-20040205/">5 February 2004 <abbr title="World Wide Web Consortium">W3C</abbr> Patent Policy</a>. <abbr title="World Wide Web Consortium">W3C</abbr> maintains a <a href="http://www.w3.org/2004/01/pp-impl/45211/status" rel="disclosure">public list of any
-    patent disclosures</a> made in connection with the deliverables of the group; that page also
-    includes instructions for disclosing a patent. An individual who has actual knowledge of a
-    patent which the individual believes contains <a href="http://www.w3.org/Consortium/Patent-Policy-20040205/#def-essential">Essential
-    Claim(s)</a> must disclose the information in accordance with <a href="http://www.w3.org/Consortium/Patent-Policy-20040205/#sec-Disclosure">section 6 of the <abbr title="World Wide Web Consortium">W3C</abbr> Patent Policy</a>. </p>
-   <p> This document is governed by the <a href="https://www.w3.org/2017/Process-20170301/" id="w3c_process_revision">1 March 2017
-    W3C Process Document</a>. </p>
-   <p></p>
+   <p> This document was produced by a group operating under the <a href="https://www.w3.org/Consortium/Patent-Policy/"><abbr title="World Wide Web Consortium">W3C</abbr> Patent Policy</a>. <abbr title="World Wide Web Consortium">W3C</abbr> maintains a <a href="https://www.w3.org/2004/01/pp-impl/45211/status" rel="disclosure">public list of any patent disclosures</a> made in connection with the deliverables of the group; that page also includes instructions for disclosing a patent. An individual who has actual knowledge of a patent which the individual believes contains <a href="https://www.w3.org/Consortium/Patent-Policy/#def-essential">Essential Claim(s)</a> must disclose the information in accordance with <a href="https://www.w3.org/Consortium/Patent-Policy/#sec-Disclosure">section 6 of the <abbr title="World Wide Web Consortium">W3C</abbr> Patent Policy</a>. </p>
+   <p>This document is governed by the <a href="https://www.w3.org/2018/Process-20180201/" id="w3c_process_revision">1 February 2018 W3C Process Document</a>. </p>
   </div>
   <div data-fill-with="at-risk"></div>
   <nav data-fill-with="table-of-contents" id="toc">
@@ -354,19 +345,19 @@ pre.idl.highlight { color: #708090; }
   <main>
    <h2 class="heading settled" data-level="1" id="intro"><span class="secno">1. </span><span class="content">Introduction</span><a class="self-link" href="#intro"></a></h2>
    <p><em>This section is non-normative.</em></p>
-   <p>Responsive Web Components need to respond to <a data-link-type="dfn" href="#content-rect" id="ref-for-content-rect-1">content rect</a> size changes. An example is an <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#element">Element</a></code> that displays a map:</p>
+   <p>Responsive Web Components need to respond to <a data-link-type="dfn" href="#content-rect" id="ref-for-content-rect">content rect</a> size changes. An example is an <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#element" id="ref-for-element">Element</a></code> that displays a map:</p>
    <ul>
     <li data-md="">
-     <p>it displays a map by tiling its content box with <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#element">Element</a></code> tiles.</p>
+     <p>it displays a map by tiling its content box with <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#element" id="ref-for-element①">Element</a></code> tiles.</p>
     <li data-md="">
      <p>when resized, it must redo the tiling.</p>
    </ul>
-   <p>Responsive Web Applications can already respond to <a data-link-type="dfn" href="https://www.w3.org/TR/css3-positioning/#viewport">viewport</a> size changes.
-This is done with CSS media queries, or window.<code class="idl"><a data-link-type="idl" href="https://drafts.csswg.org/cssom-view-1/#eventdef-window-resize">resize</a></code> event.</p>
+   <p>Responsive Web Applications can already respond to <a data-link-type="dfn" href="https://www.w3.org/TR/css3-positioning/#viewport" id="ref-for-viewport">viewport</a> size changes.
+This is done with CSS media queries, or window.<code class="idl"><a data-link-type="idl" href="https://drafts.csswg.org/cssom-view-1/#eventdef-window-resize" id="ref-for-eventdef-window-resize">resize</a></code> event.</p>
    <p>The ResizeObserver API is an interface for observing changes
-to <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#element">Element</a></code>'s <a data-link-type="dfn" href="#content-rect" id="ref-for-content-rect-2">content rect</a>’s width and height. It is an <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#element">Element</a></code>'s
-counterpart to window.<code class="idl"><a data-link-type="idl" href="https://drafts.csswg.org/cssom-view-1/#eventdef-window-resize">resize</a></code> event.</p>
-   <p>ResizeObserver’s notifications can be used to respond to changes in <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#element">Element</a></code>'s size. Some interesting facts about these observations:</p>
+to <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#element" id="ref-for-element②">Element</a></code>'s <a data-link-type="dfn" href="#content-rect" id="ref-for-content-rect①">content rect</a>’s width and height. It is an <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#element" id="ref-for-element③">Element</a></code>'s
+counterpart to window.<code class="idl"><a data-link-type="idl" href="https://drafts.csswg.org/cssom-view-1/#eventdef-window-resize" id="ref-for-eventdef-window-resize①">resize</a></code> event.</p>
+   <p>ResizeObserver’s notifications can be used to respond to changes in <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#element" id="ref-for-element④">Element</a></code>'s size. Some interesting facts about these observations:</p>
    <ul>
     <li data-md="">
      <p>observation will fire when watched Element is inserted/removed from DOM.</p>
@@ -379,27 +370,27 @@ counterpart to window.<code class="idl"><a data-link-type="idl" href="https://dr
     <li data-md="">
      <p>observation will fire when observation starts if Element has display, and Element’s size is not 0,0.</p>
    </ul>
-   <div class="example" id="example-3c1c0b9e">
-    <a class="self-link" href="#example-3c1c0b9e"></a>
-<pre class="highlight"><span class="p">&lt;</span><span class="nt">canvas</span> <span class="na">id</span><span class="o">=</span><span class="s">"elipse"</span> <span class="na">style</span><span class="o">=</span><span class="s">"display:block"</span><span class="p">></span><span class="p">&lt;</span><span class="p">/</span><span class="nt">canvas</span><span class="p">></span>
+   <div class="example" id="example-631f11c3">
+    <a class="self-link" href="#example-631f11c3"></a> 
+<pre class="highlight"><span class="p">&lt;</span><span class="nt">canvas</span> <span class="na">id</span><span class="o">=</span><span class="s">"elipse"</span> <span class="na">style</span><span class="o">=</span><span class="s">"display:block"</span><span class="p">>&lt;/</span><span class="nt">canvas</span><span class="p">></span>
 <span class="p">&lt;</span><span class="nt">div</span> <span class="na">id</span><span class="o">=</span><span class="s">"menu"</span> <span class="na">style</span><span class="o">=</span><span class="s">"display:block;width:100px"</span><span class="p">></span>
     <span class="p">&lt;</span><span class="nt">img</span> <span class="na">src</span><span class="o">=</span><span class="s">"hamburger.jpg"</span> <span class="na">style</span><span class="o">=</span><span class="s">"width:24px;height:24px"</span><span class="p">></span>
-    <span class="p">&lt;</span><span class="nt">p</span> <span class="na">class</span><span class="o">=</span><span class="s">"title"</span><span class="p">></span>menu title<span class="p">&lt;</span><span class="p">/</span><span class="nt">p</span><span class="p">></span>
-<span class="p">&lt;</span><span class="p">/</span><span class="nt">div</span><span class="p">></span>
+    <span class="p">&lt;</span><span class="nt">p</span> <span class="na">class</span><span class="o">=</span><span class="s">"title"</span><span class="p">></span>menu title<span class="p">&lt;/</span><span class="nt">p</span><span class="p">></span>
+<span class="p">&lt;/</span><span class="nt">div</span><span class="p">></span>
 </pre>
-<pre class="highlight"><span class="c1">// In response to resize, elipse paints an elipse inside a canvas
-</span>document<span class="p">.</span>querySelector<span class="p">(</span><span class="s1">'#elipse'</span><span class="p">)</span><span class="p">.</span>handleResize <span class="o">=</span> entry <span class="p">=></span> <span class="p">{</span>
+<pre class="highlight"><span class="c1">// In response to resize, elipse paints an elipse inside a canvas</span>
+<span class="c1"></span>document<span class="p">.</span>querySelector<span class="p">(</span><span class="s1">'#elipse'</span><span class="p">).</span>handleResize <span class="o">=</span> entry <span class="p">=></span> <span class="p">{</span>
     entry<span class="p">.</span>target<span class="p">.</span>width <span class="o">=</span> entry<span class="p">.</span>contentRect<span class="p">.</span>width<span class="p">;</span>
     entry<span class="p">.</span>target<span class="p">.</span>height <span class="o">=</span> entry<span class="p">.</span>contentRect<span class="p">.</span>height<span class="p">;</span>
-    <span class="kd">let</span> rx <span class="o">=</span> Math<span class="p">.</span>floor<span class="p">(</span>entry<span class="p">.</span>contentRect<span class="p">.</span>width <span class="o">/</span> <span class="mi">2</span><span class="p">)</span><span class="p">;</span>
-    <span class="kd">let</span> ry <span class="o">=</span> Math<span class="p">.</span>floor<span class="p">(</span>entry<span class="p">.</span>contentRect<span class="p">.</span>height <span class="o">/</span> <span class="mi">2</span><span class="p">)</span><span class="p">;</span>
-    <span class="kd">let</span> ctx <span class="o">=</span> entry<span class="p">.</span>target<span class="p">.</span>getContext<span class="p">(</span><span class="s1">'2d'</span><span class="p">)</span><span class="p">;</span>
-    ctx<span class="p">.</span>beginPath<span class="p">(</span><span class="p">)</span><span class="p">;</span>
-    ctx<span class="p">.</span>ellipse<span class="p">(</span>rx<span class="p">,</span> ry<span class="p">,</span> rx<span class="p">,</span> ry<span class="p">,</span> <span class="mi">0</span><span class="p">,</span> <span class="mi">0</span><span class="p">,</span> <span class="mi">2</span> <span class="o">*</span> Math<span class="p">.</span>PI<span class="p">)</span><span class="p">;</span>
-    ctx<span class="p">.</span>stroke<span class="p">(</span><span class="p">)</span><span class="p">;</span>
+    <span class="kd">let</span> rx <span class="o">=</span> Math<span class="p">.</span>floor<span class="p">(</span>entry<span class="p">.</span>contentRect<span class="p">.</span>width <span class="o">/</span> <span class="mi">2</span><span class="p">);</span>
+    <span class="kd">let</span> ry <span class="o">=</span> Math<span class="p">.</span>floor<span class="p">(</span>entry<span class="p">.</span>contentRect<span class="p">.</span>height <span class="o">/</span> <span class="mi">2</span><span class="p">);</span>
+    <span class="kd">let</span> ctx <span class="o">=</span> entry<span class="p">.</span>target<span class="p">.</span>getContext<span class="p">(</span><span class="s1">'2d'</span><span class="p">);</span>
+    ctx<span class="p">.</span>beginPath<span class="p">();</span>
+    ctx<span class="p">.</span>ellipse<span class="p">(</span>rx<span class="p">,</span> ry<span class="p">,</span> rx<span class="p">,</span> ry<span class="p">,</span> <span class="mi">0</span><span class="p">,</span> <span class="mi">0</span><span class="p">,</span> <span class="mi">2</span> <span class="o">*</span> Math<span class="p">.</span>PI<span class="p">);</span>
+    ctx<span class="p">.</span>stroke<span class="p">();</span>
 <span class="p">}</span>
-<span class="c1">// In response to resize, change title visibility depending on width
-</span>document<span class="p">.</span>querySelector<span class="p">(</span><span class="s1">'#menu'</span><span class="p">)</span><span class="p">.</span>handleResize <span class="o">=</span> entry <span class="p">=></span> <span class="p">{</span>
+<span class="c1">// In response to resize, change title visibility depending on width</span>
+<span class="c1"></span>document<span class="p">.</span>querySelector<span class="p">(</span><span class="s1">'#menu'</span><span class="p">).</span>handleResize <span class="o">=</span> entry <span class="p">=></span> <span class="p">{</span>
     <span class="kd">let</span> title <span class="o">=</span> entry<span class="p">.</span>target<span class="p">.</span>querySelector<span class="p">(</span><span class="s2">".title"</span><span class="p">)</span>
     <span class="k">if</span> <span class="p">(</span>entry<span class="p">.</span>contentRect<span class="p">.</span>width <span class="o">&lt;</span> <span class="mi">40</span><span class="p">)</span>
         title<span class="p">.</span>style<span class="p">.</span>display <span class="o">=</span> <span class="s2">"none"</span><span class="p">;</span>
@@ -409,114 +400,114 @@ counterpart to window.<code class="idl"><a data-link-type="idl" href="https://dr
 
 <span class="kd">var</span> ro <span class="o">=</span> <span class="k">new</span> ResizeObserver<span class="p">(</span> entries <span class="p">=></span> <span class="p">{</span>
   <span class="k">for</span> <span class="p">(</span><span class="kd">let</span> entry <span class="k">of</span> entries<span class="p">)</span> <span class="p">{</span>
-    <span class="kd">let</span> cs <span class="o">=</span> window<span class="p">.</span>getComputedStyle<span class="p">(</span>entry<span class="p">.</span>target<span class="p">)</span><span class="p">;</span>
-    console<span class="p">.</span>log<span class="p">(</span><span class="s1">'watching element:'</span><span class="p">,</span> entry<span class="p">.</span>target<span class="p">)</span><span class="p">;</span>
-    console<span class="p">.</span>log<span class="p">(</span>entry<span class="p">.</span>contentRect<span class="p">.</span>width<span class="p">,</span><span class="s1">' is '</span><span class="p">,</span> cs<span class="p">.</span>width<span class="p">)</span><span class="p">;</span>
-    console<span class="p">.</span>log<span class="p">(</span>entry<span class="p">.</span>contentRect<span class="p">.</span>height<span class="p">,</span><span class="s1">' is '</span><span class="p">,</span> cs<span class="p">.</span>height<span class="p">)</span><span class="p">;</span>
-    console<span class="p">.</span>log<span class="p">(</span>entry<span class="p">.</span>contentRect<span class="p">.</span>top<span class="p">,</span><span class="s1">' is '</span><span class="p">,</span> cs<span class="p">.</span>paddingTop<span class="p">)</span><span class="p">;</span>
-    console<span class="p">.</span>log<span class="p">(</span>entry<span class="p">.</span>contentRect<span class="p">.</span>left<span class="p">,</span><span class="s1">' is '</span><span class="p">,</span> cs<span class="p">.</span>paddingLeft<span class="p">)</span><span class="p">;</span>
+    <span class="kd">let</span> cs <span class="o">=</span> window<span class="p">.</span>getComputedStyle<span class="p">(</span>entry<span class="p">.</span>target<span class="p">);</span>
+    console<span class="p">.</span>log<span class="p">(</span><span class="s1">'watching element:'</span><span class="p">,</span> entry<span class="p">.</span>target<span class="p">);</span>
+    console<span class="p">.</span>log<span class="p">(</span>entry<span class="p">.</span>contentRect<span class="p">.</span>width<span class="p">,</span><span class="s1">' is '</span><span class="p">,</span> cs<span class="p">.</span>width<span class="p">);</span>
+    console<span class="p">.</span>log<span class="p">(</span>entry<span class="p">.</span>contentRect<span class="p">.</span>height<span class="p">,</span><span class="s1">' is '</span><span class="p">,</span> cs<span class="p">.</span>height<span class="p">);</span>
+    console<span class="p">.</span>log<span class="p">(</span>entry<span class="p">.</span>contentRect<span class="p">.</span>top<span class="p">,</span><span class="s1">' is '</span><span class="p">,</span> cs<span class="p">.</span>paddingTop<span class="p">);</span>
+    console<span class="p">.</span>log<span class="p">(</span>entry<span class="p">.</span>contentRect<span class="p">.</span>left<span class="p">,</span><span class="s1">' is '</span><span class="p">,</span> cs<span class="p">.</span>paddingLeft<span class="p">);</span>
     <span class="k">if</span> <span class="p">(</span>entry<span class="p">.</span>target<span class="p">.</span>handleResize<span class="p">)</span>
-        entry<span class="p">.</span>target<span class="p">.</span>handleResize<span class="p">(</span>entry<span class="p">)</span><span class="p">;</span>
+        entry<span class="p">.</span>target<span class="p">.</span>handleResize<span class="p">(</span>entry<span class="p">);</span>
   <span class="p">}</span>
-<span class="p">}</span><span class="p">)</span><span class="p">;</span>
-ro<span class="p">.</span>observe<span class="p">(</span>document<span class="p">.</span>querySelector<span class="p">(</span><span class="s1">'#elipse'</span><span class="p">)</span><span class="p">)</span><span class="p">;</span>
-ro<span class="p">.</span>observe<span class="p">(</span>document<span class="p">.</span>querySelector<span class="p">(</span><span class="s1">'#menu'</span><span class="p">)</span><span class="p">)</span><span class="p">;</span>
+<span class="p">});</span>
+ro<span class="p">.</span>observe<span class="p">(</span>document<span class="p">.</span>querySelector<span class="p">(</span><span class="s1">'#elipse'</span><span class="p">));</span>
+ro<span class="p">.</span>observe<span class="p">(</span>document<span class="p">.</span>querySelector<span class="p">(</span><span class="s1">'#menu'</span><span class="p">));</span>
 </pre>
    </div>
    <h2 class="heading settled" data-level="2" id="api"><span class="secno">2. </span><span class="content">Resize Observer API</span><a class="self-link" href="#api"></a></h2>
    <h3 class="heading settled" data-level="2.1" id="resize-observer-interface"><span class="secno">2.1. </span><span class="content">ResizeObserver interface</span><a class="self-link" href="#resize-observer-interface"></a></h3>
-   <p>The ResizeObserver interface is used to observe changes to <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#element">Element</a></code>'s <a data-link-type="dfn" href="#content-rect" id="ref-for-content-rect-3">content rect</a>.</p>
-   <p>It is modeled after <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#mutationobserver">MutationObserver</a></code> and <a data-link-type="dfn" href="https://github.com/WICG/IntersectionObserver/index.html#intersection-observer-interface">IntersectionObserver</a>.</p>
-<pre class="idl highlight def">[<a class="nv idl-code" data-link-type="constructor" href="#dom-resizeobserver-resizeobserver" id="ref-for-dom-resizeobserver-resizeobserver-1">Constructor</a>(<a class="n" data-link-type="idl-name" href="#callbackdef-resizeobservercallback" id="ref-for-callbackdef-resizeobservercallback-1">ResizeObserverCallback</a> <dfn class="nv idl-code" data-dfn-for="ResizeObserver/ResizeObserver(callback)" data-dfn-type="argument" data-export="" id="dom-resizeobserver-resizeobserver-callback-callback">callback<a class="self-link" href="#dom-resizeobserver-resizeobserver-callback-callback"></a></dfn>),
-    <a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed">Exposed</a>=<span class="n">Window</span>]
-<span class="kt">interface</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="resizeobserver">ResizeObserver</dfn> {
-    <span class="kt">void</span> <a class="nv idl-code" data-link-type="method" href="#dom-resizeobserver-observe" id="ref-for-dom-resizeobserver-observe-1">observe</a>(<a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#element">Element</a> <dfn class="nv idl-code" data-dfn-for="ResizeObserver/observe(target)" data-dfn-type="argument" data-export="" id="dom-resizeobserver-observe-target-target">target<a class="self-link" href="#dom-resizeobserver-observe-target-target"></a></dfn>);
-    <span class="kt">void</span> <a class="nv idl-code" data-link-type="method" href="#dom-resizeobserver-unobserve" id="ref-for-dom-resizeobserver-unobserve-1">unobserve</a>(<a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#element">Element</a> <dfn class="nv idl-code" data-dfn-for="ResizeObserver/unobserve(target)" data-dfn-type="argument" data-export="" id="dom-resizeobserver-unobserve-target-target">target<a class="self-link" href="#dom-resizeobserver-unobserve-target-target"></a></dfn>);
-    <span class="kt">void</span> <a class="nv idl-code" data-link-type="method" href="#dom-resizeobserver-disconnect" id="ref-for-dom-resizeobserver-disconnect-1">disconnect</a>();
+   <p>The ResizeObserver interface is used to observe changes to <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#element" id="ref-for-element⑤">Element</a></code>'s <a data-link-type="dfn" href="#content-rect" id="ref-for-content-rect②">content rect</a>.</p>
+   <p>It is modeled after <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#mutationobserver" id="ref-for-mutationobserver">MutationObserver</a></code> and <a data-link-type="dfn" href="https://github.com/WICG/IntersectionObserver/index.html#intersection-observer-interface" id="ref-for-intersection-observer-interface">IntersectionObserver</a>.</p>
+<pre class="idl highlight def">[<a class="nv idl-code" data-link-type="constructor" href="#dom-resizeobserver-resizeobserver" id="ref-for-dom-resizeobserver-resizeobserver">Constructor</a>(<a class="n" data-link-type="idl-name" href="#callbackdef-resizeobservercallback" id="ref-for-callbackdef-resizeobservercallback">ResizeObserverCallback</a> <dfn class="nv idl-code" data-dfn-for="ResizeObserver/ResizeObserver(callback)" data-dfn-type="argument" data-export="" id="dom-resizeobserver-resizeobserver-callback-callback"><code>callback</code><a class="self-link" href="#dom-resizeobserver-resizeobserver-callback-callback"></a></dfn>),
+    <a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed">Exposed</a>=<span class="n">Window</span>]
+<span class="kt">interface</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="resizeobserver"><code>ResizeObserver</code></dfn> {
+    <span class="kt">void</span> <a class="nv idl-code" data-link-type="method" href="#dom-resizeobserver-observe" id="ref-for-dom-resizeobserver-observe">observe</a>(<a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#element" id="ref-for-element⑥">Element</a> <dfn class="nv idl-code" data-dfn-for="ResizeObserver/observe(target)" data-dfn-type="argument" data-export="" id="dom-resizeobserver-observe-target-target"><code>target</code><a class="self-link" href="#dom-resizeobserver-observe-target-target"></a></dfn>);
+    <span class="kt">void</span> <a class="nv idl-code" data-link-type="method" href="#dom-resizeobserver-unobserve" id="ref-for-dom-resizeobserver-unobserve">unobserve</a>(<a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#element" id="ref-for-element⑦">Element</a> <dfn class="nv idl-code" data-dfn-for="ResizeObserver/unobserve(target)" data-dfn-type="argument" data-export="" id="dom-resizeobserver-unobserve-target-target"><code>target</code><a class="self-link" href="#dom-resizeobserver-unobserve-target-target"></a></dfn>);
+    <span class="kt">void</span> <a class="nv idl-code" data-link-type="method" href="#dom-resizeobserver-disconnect" id="ref-for-dom-resizeobserver-disconnect">disconnect</a>();
 };
 </pre>
    <div>
     <dl>
-     <dt data-md=""><dfn class="dfn-paneled idl-code" data-dfn-for="ResizeObserver" data-dfn-type="constructor" data-export="" data-lt="ResizeObserver(callback)" id="dom-resizeobserver-resizeobserver">new ResizeObserver(callback)</dfn>
+     <dt data-md=""><dfn class="dfn-paneled idl-code" data-dfn-for="ResizeObserver" data-dfn-type="constructor" data-export="" data-lt="ResizeObserver(callback)" id="dom-resizeobserver-resizeobserver"><code>new ResizeObserver(callback)</code></dfn>
      <dd data-md="">
       <ol>
        <li data-md="">
-        <p>Let <var>this</var> be a new <code class="idl"><a data-link-type="idl" href="#resizeobserver" id="ref-for-resizeobserver-1">ResizeObserver</a></code> object.</p>
+        <p>Let <var>this</var> be a new <code class="idl"><a data-link-type="idl" href="#resizeobserver" id="ref-for-resizeobserver">ResizeObserver</a></code> object.</p>
        <li data-md="">
-        <p>Set <var>this</var> internal <code class="idl"><a data-link-type="idl" href="#dom-resizeobserver-callback" id="ref-for-dom-resizeobserver-callback-1">callback</a></code> slot to callback.</p>
+        <p>Set <var>this</var> internal <code class="idl"><a data-link-type="idl" href="#dom-resizeobserver-callback" id="ref-for-dom-resizeobserver-callback">callback</a></code> slot to callback.</p>
        <li data-md="">
-        <p>Add <var>this</var> to <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document">Document</a></code>'s <code class="idl"><a data-link-type="idl" href="#dom-document-resizeobservers" id="ref-for-dom-document-resizeobservers-1">resizeObservers</a></code> slot.</p>
+        <p>Add <var>this</var> to <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document">Document</a></code>'s <code class="idl"><a data-link-type="idl" href="#dom-document-resizeobservers" id="ref-for-dom-document-resizeobservers">resizeObservers</a></code> slot.</p>
       </ol>
-     <dt data-md=""><dfn class="dfn-paneled idl-code" data-dfn-for="ResizeObserver" data-dfn-type="method" data-export="" id="dom-resizeobserver-observe">observe(target)</dfn>
+     <dt data-md=""><dfn class="dfn-paneled idl-code" data-dfn-for="ResizeObserver" data-dfn-type="method" data-export="" id="dom-resizeobserver-observe"><code>observe(target)</code></dfn>
      <dd data-md="">
       <p>Adds target to the list of observed elements.</p>
       <ol>
        <li data-md="">
-        <p>If <var>target</var> is in <code class="idl"><a data-link-type="idl" href="#dom-resizeobserver-observationtargets" id="ref-for-dom-resizeobserver-observationtargets-1">observationTargets</a></code> slot, return.</p>
+        <p>If <var>target</var> is in <code class="idl"><a data-link-type="idl" href="#dom-resizeobserver-observationtargets" id="ref-for-dom-resizeobserver-observationtargets">observationTargets</a></code> slot, return.</p>
        <li data-md="">
-        <p>Let <var>resizeObservation</var> be new <code class="idl"><a data-link-type="idl" href="#resizeobservation" id="ref-for-resizeobservation-1">ResizeObservation</a></code>(<var>target</var>).</p>
+        <p>Let <var>resizeObservation</var> be new <code class="idl"><a data-link-type="idl" href="#resizeobservation" id="ref-for-resizeobservation">ResizeObservation</a></code>(<var>target</var>).</p>
        <li data-md="">
-        <p>Add the <var>resizeObservation</var> to the <code class="idl"><a data-link-type="idl" href="#dom-resizeobserver-observationtargets" id="ref-for-dom-resizeobserver-observationtargets-2">observationTargets</a></code> slot.</p>
+        <p>Add the <var>resizeObservation</var> to the <code class="idl"><a data-link-type="idl" href="#dom-resizeobserver-observationtargets" id="ref-for-dom-resizeobserver-observationtargets①">observationTargets</a></code> slot.</p>
       </ol>
-     <dt data-md=""><dfn class="dfn-paneled idl-code" data-dfn-for="ResizeObserver" data-dfn-type="method" data-export="" id="dom-resizeobserver-unobserve">unobserve(target)</dfn>
+     <dt data-md=""><dfn class="dfn-paneled idl-code" data-dfn-for="ResizeObserver" data-dfn-type="method" data-export="" id="dom-resizeobserver-unobserve"><code>unobserve(target)</code></dfn>
      <dd data-md="">
       <p>Removes <var>target</var> from the list of observed elements.</p>
       <ol>
        <li data-md="">
-        <p>Let <var>observation</var> be <code class="idl"><a data-link-type="idl" href="#resizeobservation" id="ref-for-resizeobservation-2">ResizeObservation</a></code> in <code class="idl"><a data-link-type="idl" href="#dom-resizeobserver-observationtargets" id="ref-for-dom-resizeobserver-observationtargets-3">observationTargets</a></code> whose target slot is <var>target</var>.</p>
+        <p>Let <var>observation</var> be <code class="idl"><a data-link-type="idl" href="#resizeobservation" id="ref-for-resizeobservation①">ResizeObservation</a></code> in <code class="idl"><a data-link-type="idl" href="#dom-resizeobserver-observationtargets" id="ref-for-dom-resizeobserver-observationtargets②">observationTargets</a></code> whose target slot is <var>target</var>.</p>
        <li data-md="">
         <p>If <var>observation</var> is not found, return.</p>
        <li data-md="">
-        <p>Remove <var>observation</var> from <code class="idl"><a data-link-type="idl" href="#dom-resizeobserver-observationtargets" id="ref-for-dom-resizeobserver-observationtargets-4">observationTargets</a></code></p>
+        <p>Remove <var>observation</var> from <code class="idl"><a data-link-type="idl" href="#dom-resizeobserver-observationtargets" id="ref-for-dom-resizeobserver-observationtargets③">observationTargets</a></code></p>
       </ol>
-     <dt data-md=""><dfn class="dfn-paneled idl-code" data-dfn-for="ResizeObserver" data-dfn-type="method" data-export="" id="dom-resizeobserver-disconnect">disconnect()</dfn>
+     <dt data-md=""><dfn class="dfn-paneled idl-code" data-dfn-for="ResizeObserver" data-dfn-type="method" data-export="" id="dom-resizeobserver-disconnect"><code>disconnect()</code></dfn>
      <dd data-md="">
-      <p>1) Clear the <code class="idl"><a data-link-type="idl" href="#dom-resizeobserver-observationtargets" id="ref-for-dom-resizeobserver-observationtargets-5">observationTargets</a></code> list.</p>
-      <p>2) Clear the <code class="idl"><a data-link-type="idl" href="#dom-resizeobserver-activetargets" id="ref-for-dom-resizeobserver-activetargets-1">activeTargets</a></code> list.</p>
+      <p>1) Clear the <code class="idl"><a data-link-type="idl" href="#dom-resizeobserver-observationtargets" id="ref-for-dom-resizeobserver-observationtargets④">observationTargets</a></code> list.</p>
+      <p>2) Clear the <code class="idl"><a data-link-type="idl" href="#dom-resizeobserver-activetargets" id="ref-for-dom-resizeobserver-activetargets">activeTargets</a></code> list.</p>
     </dl>
    </div>
    <h3 class="heading settled" data-level="2.2" id="resize-observer-callback"><span class="secno">2.2. </span><span class="content">ResizeObserverCallback</span><a class="self-link" href="#resize-observer-callback"></a></h3>
-<pre class="idl highlight def"><span class="kt">callback</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="callback" data-export="" id="callbackdef-resizeobservercallback">ResizeObserverCallback</dfn> = <span class="kt">void</span> (<span class="kt">sequence</span>&lt;<a class="n" data-link-type="idl-name" href="#resizeobserverentry" id="ref-for-resizeobserverentry-1">ResizeObserverEntry</a>> <dfn class="nv idl-code" data-dfn-for="ResizeObserverCallback" data-dfn-type="argument" data-export="" id="dom-resizeobservercallback-entries">entries<a class="self-link" href="#dom-resizeobservercallback-entries"></a></dfn>, <a class="n" data-link-type="idl-name" href="#resizeobserver" id="ref-for-resizeobserver-2">ResizeObserver</a> <dfn class="nv idl-code" data-dfn-for="ResizeObserverCallback" data-dfn-type="argument" data-export="" id="dom-resizeobservercallback-observer">observer<a class="self-link" href="#dom-resizeobservercallback-observer"></a></dfn>)
+<pre class="idl highlight def"><span class="kt">callback</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="callback" data-export="" id="callbackdef-resizeobservercallback"><code>ResizeObserverCallback</code></dfn> = <span class="kt">void</span> (<span class="kt">sequence</span>&lt;<a class="n" data-link-type="idl-name" href="#resizeobserverentry" id="ref-for-resizeobserverentry">ResizeObserverEntry</a>> <dfn class="nv idl-code" data-dfn-for="ResizeObserverCallback" data-dfn-type="argument" data-export="" id="dom-resizeobservercallback-entries"><code>entries</code><a class="self-link" href="#dom-resizeobservercallback-entries"></a></dfn>, <a class="n" data-link-type="idl-name" href="#resizeobserver" id="ref-for-resizeobserver①">ResizeObserver</a> <dfn class="nv idl-code" data-dfn-for="ResizeObserverCallback" data-dfn-type="argument" data-export="" id="dom-resizeobservercallback-observer"><code>observer</code><a class="self-link" href="#dom-resizeobservercallback-observer"></a></dfn>);
 </pre>
-   <p>This callback delivers <code class="idl"><a data-link-type="idl" href="#resizeobserver" id="ref-for-resizeobserver-3">ResizeObserver</a></code>'s notifications. It is invoked by a <a data-link-type="dfn" href="#broadcast-active-observations" id="ref-for-broadcast-active-observations-1">broadcast active observations</a> algorithm.</p>
+   <p>This callback delivers <code class="idl"><a data-link-type="idl" href="#resizeobserver" id="ref-for-resizeobserver②">ResizeObserver</a></code>'s notifications. It is invoked by a <a data-link-type="dfn" href="#broadcast-active-observations" id="ref-for-broadcast-active-observations">broadcast active observations</a> algorithm.</p>
    <h3 class="heading settled" data-level="2.3" id="resize-observer-entry-interface"><span class="secno">2.3. </span><span class="content">ResizeObserverEntry</span><a class="self-link" href="#resize-observer-entry-interface"></a></h3>
-<pre class="idl highlight def">[<a class="nv idl-code" data-link-type="constructor" href="#dom-resizeobserverentry-resizeobserverentry" id="ref-for-dom-resizeobserverentry-resizeobserverentry-1">Constructor</a>(<a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#element">Element</a> <dfn class="nv idl-code" data-dfn-for="ResizeObserverEntry/ResizeObserverEntry(target)" data-dfn-type="argument" data-export="" id="dom-resizeobserverentry-resizeobserverentry-target-target">target<a class="self-link" href="#dom-resizeobserverentry-resizeobserverentry-target-target"></a></dfn>)
+<pre class="idl highlight def">[<a class="nv idl-code" data-link-type="constructor" href="#dom-resizeobserverentry-resizeobserverentry" id="ref-for-dom-resizeobserverentry-resizeobserverentry">Constructor</a>(<a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#element" id="ref-for-element⑧">Element</a> <dfn class="nv idl-code" data-dfn-for="ResizeObserverEntry/ResizeObserverEntry(target)" data-dfn-type="argument" data-export="" id="dom-resizeobserverentry-resizeobserverentry-target-target"><code>target</code><a class="self-link" href="#dom-resizeobserverentry-resizeobserverentry-target-target"></a></dfn>)
 ]
-<span class="kt">interface</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="resizeobserverentry">ResizeObserverEntry</dfn> {
-    <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#element">Element</a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="Element" href="#dom-resizeobserverentry-target" id="ref-for-dom-resizeobserverentry-target-1">target</a>;
-    <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="https://drafts.fxtf.org/geometry-1/#domrectreadonly">DOMRectReadOnly</a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="DOMRectReadOnly" href="#dom-resizeobserverentry-contentrect" id="ref-for-dom-resizeobserverentry-contentrect-1">contentRect</a>;
+<span class="kt">interface</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="resizeobserverentry"><code>ResizeObserverEntry</code></dfn> {
+    <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#element" id="ref-for-element⑨">Element</a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="Element" href="#dom-resizeobserverentry-target" id="ref-for-dom-resizeobserverentry-target">target</a>;
+    <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="https://drafts.fxtf.org/geometry-1/#domrectreadonly" id="ref-for-domrectreadonly">DOMRectReadOnly</a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="DOMRectReadOnly" href="#dom-resizeobserverentry-contentrect" id="ref-for-dom-resizeobserverentry-contentrect">contentRect</a>;
 };
 </pre>
    <div>
     <dl>
-     <dt data-md=""><dfn class="dfn-paneled idl-code" data-dfn-for="ResizeObserverEntry" data-dfn-type="attribute" data-export="" id="dom-resizeobserverentry-target">target</dfn>, <span> of type <a data-link-type="idl-name" href="https://dom.spec.whatwg.org/#element">Element</a>, readonly</span>
+     <dt data-md=""><dfn class="dfn-paneled idl-code" data-dfn-for="ResizeObserverEntry" data-dfn-type="attribute" data-export="" id="dom-resizeobserverentry-target"><code>target</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://dom.spec.whatwg.org/#element" id="ref-for-element①⓪">Element</a>, readonly</span>
      <dd data-md="">
-      <p>The <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#element">Element</a></code> whose size has changed.</p>
-     <dt data-md=""><dfn class="dfn-paneled idl-code" data-dfn-for="ResizeObserverEntry" data-dfn-type="attribute" data-export="" id="dom-resizeobserverentry-contentrect">contentRect</dfn>, <span> of type <a data-link-type="idl-name" href="https://drafts.fxtf.org/geometry-1/#domrectreadonly">DOMRectReadOnly</a>, readonly</span>
+      <p>The <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#element" id="ref-for-element①①">Element</a></code> whose size has changed.</p>
+     <dt data-md=""><dfn class="dfn-paneled idl-code" data-dfn-for="ResizeObserverEntry" data-dfn-type="attribute" data-export="" id="dom-resizeobserverentry-contentrect"><code>contentRect</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://drafts.fxtf.org/geometry-1/#domrectreadonly" id="ref-for-domrectreadonly①">DOMRectReadOnly</a>, readonly</span>
      <dd data-md="">
-      <p><code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#element">Element</a></code>'s <a data-link-type="dfn" href="#content-rect" id="ref-for-content-rect-4">content rect</a> when <code class="idl"><a data-link-type="idl" href="#callbackdef-resizeobservercallback" id="ref-for-callbackdef-resizeobservercallback-2">ResizeObserverCallback</a></code> is invoked.</p>
+      <p><code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#element" id="ref-for-element①②">Element</a></code>'s <a data-link-type="dfn" href="#content-rect" id="ref-for-content-rect③">content rect</a> when <code class="idl"><a data-link-type="idl" href="#callbackdef-resizeobservercallback" id="ref-for-callbackdef-resizeobservercallback①">ResizeObserverCallback</a></code> is invoked.</p>
     </dl>
    </div>
    <div>
     <dl>
-     <dt data-md=""><dfn class="dfn-paneled idl-code" data-dfn-for="ResizeObserverEntry" data-dfn-type="constructor" data-export="" data-lt="ResizeObserverEntry(target)" id="dom-resizeobserverentry-resizeobserverentry">new ResizeObserverEntry(target)</dfn>
+     <dt data-md=""><dfn class="dfn-paneled idl-code" data-dfn-for="ResizeObserverEntry" data-dfn-type="constructor" data-export="" data-lt="ResizeObserverEntry(target)" id="dom-resizeobserverentry-resizeobserverentry"><code>new ResizeObserverEntry(target)</code></dfn>
      <dd data-md="">
       <ol>
        <li data-md="">
-        <p>Let <var>this</var> be a new <code class="idl"><a data-link-type="idl" href="#resizeobserverentry" id="ref-for-resizeobserverentry-2">ResizeObserverEntry</a></code>.</p>
+        <p>Let <var>this</var> be a new <code class="idl"><a data-link-type="idl" href="#resizeobserverentry" id="ref-for-resizeobserverentry①">ResizeObserverEntry</a></code>.</p>
        <li data-md="">
-        <p>Set <var>this</var> <code class="idl"><a data-link-type="idl" href="#dom-resizeobserverentry-target" id="ref-for-dom-resizeobserverentry-target-2">target</a></code> slot to <var>target</var>.</p>
+        <p>Set <var>this</var> <code class="idl"><a data-link-type="idl" href="#dom-resizeobserverentry-target" id="ref-for-dom-resizeobserverentry-target①">target</a></code> slot to <var>target</var>.</p>
        <li data-md="">
         <p>If <var>target</var> is not an SVG element do these steps:</p>
         <ol>
          <li data-md="">
-          <p>Set <var>this</var>.contentRect.width to <var>target</var>.<a data-link-type="dfn" href="https://www.w3.org/TR/CSS2/box.html#content-width">content width</a>.</p>
+          <p>Set <var>this</var>.contentRect.width to <var>target</var>.<a data-link-type="dfn" href="https://www.w3.org/TR/CSS2/box.html#content-width" id="ref-for-content-width">content width</a>.</p>
          <li data-md="">
-          <p>Set <var>this</var>.contentRect.height to <var>target</var>.<a data-link-type="dfn" href="https://www.w3.org/TR/CSS2/box.html#content-height">content height</a>.</p>
+          <p>Set <var>this</var>.contentRect.height to <var>target</var>.<a data-link-type="dfn" href="https://www.w3.org/TR/CSS2/box.html#content-height" id="ref-for-content-height">content height</a>.</p>
          <li data-md="">
-          <p>Set <var>this</var>.contentRect.top to <var>target</var>.<a data-link-type="dfn" href="https://drafts.csswg.org/css-box-3/#padding-top">padding top</a>.</p>
+          <p>Set <var>this</var>.contentRect.top to <var>target</var>.<a data-link-type="dfn" href="https://drafts.csswg.org/css-box-3/#padding-top" id="ref-for-padding-top">padding top</a>.</p>
          <li data-md="">
-          <p>Set <var>this</var>.contentRect.left to <var>target</var>.<a data-link-type="dfn" href="https://drafts.csswg.org/css-box-3/#padding-left">padding left</a>.</p>
+          <p>Set <var>this</var>.contentRect.left to <var>target</var>.<a data-link-type="dfn" href="https://drafts.csswg.org/css-box-3/#padding-left" id="ref-for-padding-left">padding left</a>.</p>
         </ol>
        <li data-md="">
         <p>If <var>target</var> is an SVG element do these steps:</p>
@@ -524,70 +515,70 @@ ro<span class="p">.</span>observe<span class="p">(</span>document<span class="p"
          <li data-md="">
           <p>Set <var>this</var>.contentRect.top and <var>this</var>.contentRect.left to 0.</p>
          <li data-md="">
-          <p>Set <var>this</var>.contentRect.width to <var>target</var>.<a data-link-type="dfn" href="https://www.w3.org/TR/SVG2/coords.html#BoundingBoxes">bounding box</a>.width.</p>
+          <p>Set <var>this</var>.contentRect.width to <var>target</var>.<a data-link-type="dfn" href="https://www.w3.org/TR/SVG2/coords.html#BoundingBoxes" id="ref-for-BoundingBoxes">bounding box</a>.width.</p>
          <li data-md="">
-          <p>Set <var>this</var>.contentRect.height to <var>target</var>.<a data-link-type="dfn" href="https://www.w3.org/TR/SVG2/coords.html#BoundingBoxes">bounding box</a>.height.</p>
+          <p>Set <var>this</var>.contentRect.height to <var>target</var>.<a data-link-type="dfn" href="https://www.w3.org/TR/SVG2/coords.html#BoundingBoxes" id="ref-for-BoundingBoxes①">bounding box</a>.height.</p>
         </ol>
       </ol>
     </dl>
    </div>
    <h3 class="heading settled" data-level="2.4" id="resize-observation-interface"><span class="secno">2.4. </span><span class="content">ResizeObservation</span><a class="self-link" href="#resize-observation-interface"></a></h3>
-    ResizeObservation holds observation information for a single <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#element">Element</a></code>. This
-interface is not visible to Javascript.
-<pre class="idl highlight def">[<a class="nv idl-code" data-link-type="constructor" href="#dom-resizeobservation-resizeobservation" id="ref-for-dom-resizeobservation-resizeobservation-1">Constructor</a>(<a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#element">Element</a> <dfn class="nv idl-code" data-dfn-for="ResizeObservation/ResizeObservation(target)" data-dfn-type="argument" data-export="" id="dom-resizeobservation-resizeobservation-target-target">target<a class="self-link" href="#dom-resizeobservation-resizeobservation-target-target"></a></dfn>)
+    ResizeObservation holds observation information for a single <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#element" id="ref-for-element①③">Element</a></code>. This
+interface is not visible to Javascript. 
+<pre class="idl highlight def">[<a class="nv idl-code" data-link-type="constructor" href="#dom-resizeobservation-resizeobservation" id="ref-for-dom-resizeobservation-resizeobservation">Constructor</a>(<a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#element" id="ref-for-element①④">Element</a> <dfn class="nv idl-code" data-dfn-for="ResizeObservation/ResizeObservation(target)" data-dfn-type="argument" data-export="" id="dom-resizeobservation-resizeobservation-target-target"><code>target</code><a class="self-link" href="#dom-resizeobservation-resizeobservation-target-target"></a></dfn>)
 ]
-<span class="kt">interface</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="resizeobservation">ResizeObservation</dfn> {
-    <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#element">Element</a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="Element" href="#dom-resizeobservation-target" id="ref-for-dom-resizeobservation-target-1">target</a>;
-    <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-float"><span class="kt">float</span></a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="float" href="#dom-resizeobservation-broadcastwidth" id="ref-for-dom-resizeobservation-broadcastwidth-1">broadcastWidth</a>;
-    <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-float"><span class="kt">float</span></a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="float" href="#dom-resizeobservation-broadcastheight" id="ref-for-dom-resizeobservation-broadcastheight-1">broadcastHeight</a>;
-    <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean"><span class="kt">boolean</span></a> <a class="nv idl-code" data-link-type="method" href="#dom-resizeobservation-isactive" id="ref-for-dom-resizeobservation-isactive-1">isActive</a>();
+<span class="kt">interface</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="resizeobservation"><code>ResizeObservation</code></dfn> {
+    <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#element" id="ref-for-element①⑤">Element</a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="Element" href="#dom-resizeobservation-target" id="ref-for-dom-resizeobservation-target">target</a>;
+    <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-float" id="ref-for-idl-float"><span class="kt">float</span></a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="float" href="#dom-resizeobservation-broadcastwidth" id="ref-for-dom-resizeobservation-broadcastwidth">broadcastWidth</a>;
+    <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-float" id="ref-for-idl-float①"><span class="kt">float</span></a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="float" href="#dom-resizeobservation-broadcastheight" id="ref-for-dom-resizeobservation-broadcastheight">broadcastHeight</a>;
+    <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean"><span class="kt">boolean</span></a> <a class="nv idl-code" data-link-type="method" href="#dom-resizeobservation-isactive" id="ref-for-dom-resizeobservation-isactive">isActive</a>();
 };
 </pre>
    <div>
     <dl>
-     <dt data-md=""><dfn class="dfn-paneled idl-code" data-dfn-for="ResizeObservation" data-dfn-type="attribute" data-export="" id="dom-resizeobservation-target">target</dfn>, <span> of type <a data-link-type="idl-name" href="https://dom.spec.whatwg.org/#element">Element</a>, readonly</span>
+     <dt data-md=""><dfn class="dfn-paneled idl-code" data-dfn-for="ResizeObservation" data-dfn-type="attribute" data-export="" id="dom-resizeobservation-target"><code>target</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://dom.spec.whatwg.org/#element" id="ref-for-element①⑥">Element</a>, readonly</span>
      <dd data-md="">
-      <p>The observed <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#element">Element</a></code>.</p>
-     <dt data-md=""><dfn class="dfn-paneled idl-code" data-dfn-for="ResizeObservation" data-dfn-type="attribute" data-export="" id="dom-resizeobservation-broadcastwidth">broadcastWidth</dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-float">float</a>, readonly</span>
+      <p>The observed <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#element" id="ref-for-element①⑦">Element</a></code>.</p>
+     <dt data-md=""><dfn class="dfn-paneled idl-code" data-dfn-for="ResizeObservation" data-dfn-type="attribute" data-export="" id="dom-resizeobservation-broadcastwidth"><code>broadcastWidth</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-float" id="ref-for-idl-float②">float</a>, readonly</span>
      <dd data-md="">
-      <p>Width of last broadcast <a data-link-type="dfn" href="https://www.w3.org/TR/CSS2/box.html#content-width">content width</a>.</p>
-     <dt data-md=""><dfn class="dfn-paneled idl-code" data-dfn-for="ResizeObservation" data-dfn-type="attribute" data-export="" id="dom-resizeobservation-broadcastheight">broadcastHeight</dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-float">float</a>, readonly</span>
+      <p>Width of last broadcast <a data-link-type="dfn" href="https://www.w3.org/TR/CSS2/box.html#content-width" id="ref-for-content-width①">content width</a>.</p>
+     <dt data-md=""><dfn class="dfn-paneled idl-code" data-dfn-for="ResizeObservation" data-dfn-type="attribute" data-export="" id="dom-resizeobservation-broadcastheight"><code>broadcastHeight</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-float" id="ref-for-idl-float③">float</a>, readonly</span>
      <dd data-md="">
-      <p>Width of last broadcast <a data-link-type="dfn" href="https://www.w3.org/TR/CSS2/box.html#content-height">content height</a>.</p>
+      <p>Width of last broadcast <a data-link-type="dfn" href="https://www.w3.org/TR/CSS2/box.html#content-height" id="ref-for-content-height①">content height</a>.</p>
     </dl>
    </div>
    <div>
     <dl>
-     <dt data-md=""><dfn class="dfn-paneled idl-code" data-dfn-for="ResizeObservation" data-dfn-type="constructor" data-export="" data-lt="ResizeObservation(target)" id="dom-resizeobservation-resizeobservation">new ResizeObservation(target)</dfn>
+     <dt data-md=""><dfn class="dfn-paneled idl-code" data-dfn-for="ResizeObservation" data-dfn-type="constructor" data-export="" data-lt="ResizeObservation(target)" id="dom-resizeobservation-resizeobservation"><code>new ResizeObservation(target)</code></dfn>
      <dd data-md="">
       <ol>
        <li data-md="">
-        <p>Let <var>this</var> be a new <code class="idl"><a data-link-type="idl" href="#resizeobservation" id="ref-for-resizeobservation-3">ResizeObservation</a></code> object</p>
+        <p>Let <var>this</var> be a new <code class="idl"><a data-link-type="idl" href="#resizeobservation" id="ref-for-resizeobservation②">ResizeObservation</a></code> object</p>
        <li data-md="">
-        <p>Set <var>this</var> internal <code class="idl"><a data-link-type="idl" href="#dom-resizeobservation-target" id="ref-for-dom-resizeobservation-target-2">target</a></code> slot to <var>target</var></p>
+        <p>Set <var>this</var> internal <code class="idl"><a data-link-type="idl" href="#dom-resizeobservation-target" id="ref-for-dom-resizeobservation-target①">target</a></code> slot to <var>target</var></p>
        <li data-md="">
-        <p>Set <var>this</var> <code class="idl"><a data-link-type="idl" href="#dom-resizeobservation-broadcastwidth" id="ref-for-dom-resizeobservation-broadcastwidth-2">broadcastWidth</a></code> slot to 0.</p>
+        <p>Set <var>this</var> <code class="idl"><a data-link-type="idl" href="#dom-resizeobservation-broadcastwidth" id="ref-for-dom-resizeobservation-broadcastwidth①">broadcastWidth</a></code> slot to 0.</p>
        <li data-md="">
-        <p>Set <var>this</var> <code class="idl"><a data-link-type="idl" href="#dom-resizeobservation-broadcastheight" id="ref-for-dom-resizeobservation-broadcastheight-2">broadcastHeight</a></code> slot to 0.</p>
+        <p>Set <var>this</var> <code class="idl"><a data-link-type="idl" href="#dom-resizeobservation-broadcastheight" id="ref-for-dom-resizeobservation-broadcastheight①">broadcastHeight</a></code> slot to 0.</p>
       </ol>
-     <dt data-md=""><dfn class="dfn-paneled idl-code" data-dfn-for="ResizeObservation" data-dfn-type="method" data-export="" id="dom-resizeobservation-isactive">isActive()</dfn>
+     <dt data-md=""><dfn class="dfn-paneled idl-code" data-dfn-for="ResizeObservation" data-dfn-type="method" data-export="" id="dom-resizeobservation-isactive"><code>isActive()</code></dfn>
      <dd data-md="">
       <ol>
        <li data-md="">
-        <p>If <code class="idl"><a data-link-type="idl" href="#dom-resizeobservation-target" id="ref-for-dom-resizeobservation-target-3">target</a></code> is an HTML element do these steps:</p>
+        <p>If <code class="idl"><a data-link-type="idl" href="#dom-resizeobservation-target" id="ref-for-dom-resizeobservation-target②">target</a></code> is an HTML element do these steps:</p>
         <ol>
          <li data-md="">
-          <p>If <code class="idl"><a data-link-type="idl" href="#dom-resizeobservation-target" id="ref-for-dom-resizeobservation-target-4">target</a></code>.<a data-link-type="dfn" href="https://www.w3.org/TR/CSS2/box.html#content-width">content width</a> != <code class="idl"><a data-link-type="idl" href="#dom-resizeobservation-broadcastwidth" id="ref-for-dom-resizeobservation-broadcastwidth-3">broadcastWidth</a></code> return true.</p>
+          <p>If <code class="idl"><a data-link-type="idl" href="#dom-resizeobservation-target" id="ref-for-dom-resizeobservation-target③">target</a></code>.<a data-link-type="dfn" href="https://www.w3.org/TR/CSS2/box.html#content-width" id="ref-for-content-width②">content width</a> != <code class="idl"><a data-link-type="idl" href="#dom-resizeobservation-broadcastwidth" id="ref-for-dom-resizeobservation-broadcastwidth②">broadcastWidth</a></code> return true.</p>
          <li data-md="">
-          <p>If <code class="idl"><a data-link-type="idl" href="#dom-resizeobservation-target" id="ref-for-dom-resizeobservation-target-5">target</a></code>.<a data-link-type="dfn" href="https://www.w3.org/TR/CSS2/box.html#content-height">content height</a> != <code class="idl"><a data-link-type="idl" href="#dom-resizeobservation-broadcastheight" id="ref-for-dom-resizeobservation-broadcastheight-3">broadcastHeight</a></code> return true.</p>
+          <p>If <code class="idl"><a data-link-type="idl" href="#dom-resizeobservation-target" id="ref-for-dom-resizeobservation-target④">target</a></code>.<a data-link-type="dfn" href="https://www.w3.org/TR/CSS2/box.html#content-height" id="ref-for-content-height②">content height</a> != <code class="idl"><a data-link-type="idl" href="#dom-resizeobservation-broadcastheight" id="ref-for-dom-resizeobservation-broadcastheight②">broadcastHeight</a></code> return true.</p>
         </ol>
        <li data-md="">
-        <p>If <code class="idl"><a data-link-type="idl" href="#dom-resizeobservation-target" id="ref-for-dom-resizeobservation-target-6">target</a></code> is an SVGGraphicsElement do these steps:</p>
+        <p>If <code class="idl"><a data-link-type="idl" href="#dom-resizeobservation-target" id="ref-for-dom-resizeobservation-target⑤">target</a></code> is an SVGGraphicsElement do these steps:</p>
         <ol>
          <li data-md="">
-          <p>If <code class="idl"><a data-link-type="idl" href="#dom-resizeobservation-target" id="ref-for-dom-resizeobservation-target-7">target</a></code>.bounding box width != <code class="idl"><a data-link-type="idl" href="#dom-resizeobservation-broadcastwidth" id="ref-for-dom-resizeobservation-broadcastwidth-4">broadcastWidth</a></code> return true.</p>
+          <p>If <code class="idl"><a data-link-type="idl" href="#dom-resizeobservation-target" id="ref-for-dom-resizeobservation-target⑥">target</a></code>.bounding box width != <code class="idl"><a data-link-type="idl" href="#dom-resizeobservation-broadcastwidth" id="ref-for-dom-resizeobservation-broadcastwidth③">broadcastWidth</a></code> return true.</p>
          <li data-md="">
-          <p>If <code class="idl"><a data-link-type="idl" href="#dom-resizeobservation-target" id="ref-for-dom-resizeobservation-target-8">target</a></code>.bounding box height != <code class="idl"><a data-link-type="idl" href="#dom-resizeobservation-broadcastheight" id="ref-for-dom-resizeobservation-broadcastheight-4">broadcastHeight</a></code> return true.</p>
+          <p>If <code class="idl"><a data-link-type="idl" href="#dom-resizeobservation-target" id="ref-for-dom-resizeobservation-target⑦">target</a></code>.bounding box height != <code class="idl"><a data-link-type="idl" href="#dom-resizeobservation-broadcastheight" id="ref-for-dom-resizeobservation-broadcastheight③">broadcastHeight</a></code> return true.</p>
         </ol>
        <li data-md="">
         <p>return false.</p>
@@ -597,27 +588,27 @@ interface is not visible to Javascript.
    <h2 class="heading settled" data-level="3" id="processing-model"><span class="secno">3. </span><span class="content">Processing Model</span><a class="self-link" href="#processing-model"></a></h2>
    <h3 class="heading settled" data-level="3.1" id="internal-slot-definitions"><span class="secno">3.1. </span><span class="content">Internal Slot Definitions</span><a class="self-link" href="#internal-slot-definitions"></a></h3>
    <h4 class="heading settled" data-level="3.1.1" id="document-slots"><span class="secno">3.1.1. </span><span class="content">Document</span><a class="self-link" href="#document-slots"></a></h4>
-   <p><a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document">Document</a> has a <dfn class="dfn-paneled idl-code" data-dfn-for="Document" data-dfn-type="attribute" data-export="" id="dom-document-resizeobservers">resizeObservers</dfn> slot that is a list of <code class="idl"><a data-link-type="idl" href="#resizeobserver" id="ref-for-resizeobserver-4">ResizeObserver</a></code>s in this document. It is initialized to empty.</p>
+   <p><a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document">Document</a> has a <dfn class="dfn-paneled idl-code" data-dfn-for="Document" data-dfn-type="attribute" data-export="" id="dom-document-resizeobservers"><code>resizeObservers</code></dfn> slot that is a list of <code class="idl"><a data-link-type="idl" href="#resizeobserver" id="ref-for-resizeobserver③">ResizeObserver</a></code>s in this document. It is initialized to empty.</p>
    <h4 class="heading settled" data-level="3.1.2" id="resize-observer-slots"><span class="secno">3.1.2. </span><span class="content">ResizeObserver</span><a class="self-link" href="#resize-observer-slots"></a></h4>
-   <p><code class="idl"><a data-link-type="idl" href="#resizeobserver" id="ref-for-resizeobserver-5">ResizeObserver</a></code> has a <dfn class="dfn-paneled idl-code" data-dfn-for="ResizeObserver" data-dfn-type="attribute" data-export="" id="dom-resizeobserver-callback">callback</dfn> slot, initialized by constructor.</p>
-   <p><code class="idl"><a data-link-type="idl" href="#resizeobserver" id="ref-for-resizeobserver-6">ResizeObserver</a></code> has an <dfn class="dfn-paneled idl-code" data-dfn-for="ResizeObserver" data-dfn-type="attribute" data-export="" id="dom-resizeobserver-observationtargets">observationTargets</dfn> slot, which is a list of <code class="idl"><a data-link-type="idl" href="#resizeobservation" id="ref-for-resizeobservation-4">ResizeObservation</a></code>s.
+   <p><code class="idl"><a data-link-type="idl" href="#resizeobserver" id="ref-for-resizeobserver④">ResizeObserver</a></code> has a <dfn class="dfn-paneled idl-code" data-dfn-for="ResizeObserver" data-dfn-type="attribute" data-export="" id="dom-resizeobserver-callback"><code>callback</code></dfn> slot, initialized by constructor.</p>
+   <p><code class="idl"><a data-link-type="idl" href="#resizeobserver" id="ref-for-resizeobserver⑤">ResizeObserver</a></code> has an <dfn class="dfn-paneled idl-code" data-dfn-for="ResizeObserver" data-dfn-type="attribute" data-export="" id="dom-resizeobserver-observationtargets"><code>observationTargets</code></dfn> slot, which is a list of <code class="idl"><a data-link-type="idl" href="#resizeobservation" id="ref-for-resizeobservation③">ResizeObservation</a></code>s.
 It represents all Elements being observed.</p>
-   <p><code class="idl"><a data-link-type="idl" href="#resizeobserver" id="ref-for-resizeobserver-7">ResizeObserver</a></code> has a <dfn class="dfn-paneled idl-code" data-dfn-for="ResizeObserver" data-dfn-type="attribute" data-export="" id="dom-resizeobserver-activetargets">activeTargets</dfn> slot, which is a list of <code class="idl"><a data-link-type="idl" href="#resizeobservation" id="ref-for-resizeobservation-5">ResizeObservation</a></code>s. It represents all Elements whose size has changed since last observation broadcast that are eligible for broadcast.</p>
-   <p><code class="idl"><a data-link-type="idl" href="#resizeobserver" id="ref-for-resizeobserver-8">ResizeObserver</a></code> has a <dfn class="dfn-paneled idl-code" data-dfn-for="ResizeObserver" data-dfn-type="attribute" data-export="" id="dom-resizeobserver-skippedtargets">skippedTargets</dfn> slot, which is a list of <code class="idl"><a data-link-type="idl" href="#resizeobservation" id="ref-for-resizeobservation-6">ResizeObservation</a></code>s. It represents all Elements whose size has changed since last observation broadcast that are **not** eligible for broadcast</p>
+   <p><code class="idl"><a data-link-type="idl" href="#resizeobserver" id="ref-for-resizeobserver⑥">ResizeObserver</a></code> has a <dfn class="dfn-paneled idl-code" data-dfn-for="ResizeObserver" data-dfn-type="attribute" data-export="" id="dom-resizeobserver-activetargets"><code>activeTargets</code></dfn> slot, which is a list of <code class="idl"><a data-link-type="idl" href="#resizeobservation" id="ref-for-resizeobservation④">ResizeObservation</a></code>s. It represents all Elements whose size has changed since last observation broadcast that are eligible for broadcast.</p>
+   <p><code class="idl"><a data-link-type="idl" href="#resizeobserver" id="ref-for-resizeobserver⑦">ResizeObserver</a></code> has a <dfn class="dfn-paneled idl-code" data-dfn-for="ResizeObserver" data-dfn-type="attribute" data-export="" id="dom-resizeobserver-skippedtargets"><code>skippedTargets</code></dfn> slot, which is a list of <code class="idl"><a data-link-type="idl" href="#resizeobservation" id="ref-for-resizeobservation⑤">ResizeObservation</a></code>s. It represents all Elements whose size has changed since last observation broadcast that are **not** eligible for broadcast</p>
    <h3 class="heading settled" data-level="3.2" id="css-definitions"><span class="secno">3.2. </span><span class="content">CSS Definitions</span><a class="self-link" href="#css-definitions"></a></h3>
    <h4 class="heading settled" data-level="3.2.1" id="content-rect-h"><span class="secno">3.2.1. </span><span class="content">content rect</span><a class="self-link" href="#content-rect-h"></a></h4>
-    DOM <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="content-rect">content rect</dfn> is a rect whose:
+    DOM <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="content-rect">content rect</dfn> is a rect whose: 
    <ul>
     <li data-md="">
-     <p>width is <a data-link-type="dfn" href="https://www.w3.org/TR/CSS2/box.html#content-width">content width</a></p>
+     <p>width is <a data-link-type="dfn" href="https://www.w3.org/TR/CSS2/box.html#content-width" id="ref-for-content-width③">content width</a></p>
     <li data-md="">
-     <p>height is <a data-link-type="dfn" href="https://www.w3.org/TR/CSS2/box.html#content-height">content height</a></p>
+     <p>height is <a data-link-type="dfn" href="https://www.w3.org/TR/CSS2/box.html#content-height" id="ref-for-content-height③">content height</a></p>
     <li data-md="">
-     <p>top is <a data-link-type="dfn" href="https://drafts.csswg.org/css-box-3/#padding-top">padding top</a></p>
+     <p>top is <a data-link-type="dfn" href="https://drafts.csswg.org/css-box-3/#padding-top" id="ref-for-padding-top①">padding top</a></p>
     <li data-md="">
-     <p>left is <a data-link-type="dfn" href="https://drafts.csswg.org/css-box-3/#padding-left">padding left</a></p>
+     <p>left is <a data-link-type="dfn" href="https://drafts.csswg.org/css-box-3/#padding-left" id="ref-for-padding-left①">padding left</a></p>
    </ul>
-   <p><a data-link-type="dfn" href="https://www.w3.org/TR/CSS2/box.html#content-width">content width</a> spec does not mention how <a data-link-type="dfn" href="https://www.w3.org/TR/css3-multicol/#">multi-column</a> layout affects content box. In this spec, content width of an <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#element">Element</a></code> inside <a data-link-type="dfn" href="https://www.w3.org/TR/css3-multicol/#">multi-column</a> is the result of getComputedStyle(<code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#element">Element</a></code>).width. This currently evaluates to width of the first column.</p>
+   <p><a data-link-type="dfn" href="https://www.w3.org/TR/CSS2/box.html#content-width" id="ref-for-content-width④">content width</a> spec does not mention how <a data-link-type="dfn" href="https://www.w3.org/TR/css3-multicol/#">multi-column</a> layout affects content box. In this spec, content width of an <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#element" id="ref-for-element①⑧">Element</a></code> inside <a data-link-type="dfn" href="https://www.w3.org/TR/css3-multicol/#">multi-column</a> is the result of getComputedStyle(<code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#element" id="ref-for-element①⑨">Element</a></code>).width. This currently evaluates to width of the first column.</p>
    <p>Having content rect position be padding-top/left is useful for absolute positioning of target’s children. Absolute position coordinate space origin is topLeft of the padding rect.</p>
    <p>Watching content rect means that:</p>
    <ul>
@@ -630,13 +621,13 @@ It represents all Elements being observed.</p>
     <li data-md="">
      <p>observations will not be triggered by CSS transforms.</p>
    </ul>
-   <p>Web content can also contain SVG elements. SVG Elements define <a data-link-type="dfn" href="https://www.w3.org/TR/SVG2/coords.html#BoundingBoxes">bounding box</a> instead of a content box.
-Content rect for <a data-link-type="dfn" href="https://www.w3.org/TR/SVG2/#InterfaceSVGGraphicsElementtypes.html#InterfaceSVGGraphicsElement">SVGGraphicsElement</a>s is a rect whose:</p>
+   <p>Web content can also contain SVG elements. SVG Elements define <a data-link-type="dfn" href="https://www.w3.org/TR/SVG2/coords.html#BoundingBoxes" id="ref-for-BoundingBoxes②">bounding box</a> instead of a content box.
+Content rect for <a data-link-type="dfn" href="https://www.w3.org/TR/SVG2/#InterfaceSVGGraphicsElementtypes.html#InterfaceSVGGraphicsElement" id="ref-for-InterfaceSVGGraphicsElementtypes.html#InterfaceSVGGraphicsElement">SVGGraphicsElement</a>s is a rect whose:</p>
    <ul>
     <li data-md="">
-     <p>width is <a data-link-type="dfn" href="https://www.w3.org/TR/SVG2/coords.html#BoundingBoxes">bounding box</a> width</p>
+     <p>width is <a data-link-type="dfn" href="https://www.w3.org/TR/SVG2/coords.html#BoundingBoxes" id="ref-for-BoundingBoxes③">bounding box</a> width</p>
     <li data-md="">
-     <p>height is <a data-link-type="dfn" href="https://www.w3.org/TR/SVG2/coords.html#BoundingBoxes">bounding box</a> height</p>
+     <p>height is <a data-link-type="dfn" href="https://www.w3.org/TR/SVG2/coords.html#BoundingBoxes" id="ref-for-BoundingBoxes④">bounding box</a> height</p>
     <li data-md="">
      <p>top and left are 0</p>
    </ul>
@@ -647,46 +638,46 @@ Content rect for <a data-link-type="dfn" href="https://www.w3.org/TR/SVG2/#Inter
     <li data-md="">
      <p>Let <var>depth</var> be the depth passed in.</p>
     <li data-md="">
-     <p>For each <var>observer</var> in <code class="idl"><a data-link-type="idl" href="#dom-document-resizeobservers" id="ref-for-dom-document-resizeobservers-2">resizeObservers</a></code> run these steps:</p>
+     <p>For each <var>observer</var> in <code class="idl"><a data-link-type="idl" href="#dom-document-resizeobservers" id="ref-for-dom-document-resizeobservers①">resizeObservers</a></code> run these steps:</p>
      <ol>
       <li data-md="">
-       <p>Clear <var>observer</var>’s <code class="idl"><a data-link-type="idl" href="#dom-resizeobserver-activetargets" id="ref-for-dom-resizeobserver-activetargets-2">activeTargets</a></code>, and <code class="idl"><a data-link-type="idl" href="#dom-resizeobserver-skippedtargets" id="ref-for-dom-resizeobserver-skippedtargets-1">skippedTargets</a></code></p>
+       <p>Clear <var>observer</var>’s <code class="idl"><a data-link-type="idl" href="#dom-resizeobserver-activetargets" id="ref-for-dom-resizeobserver-activetargets①">activeTargets</a></code>, and <code class="idl"><a data-link-type="idl" href="#dom-resizeobserver-skippedtargets" id="ref-for-dom-resizeobserver-skippedtargets">skippedTargets</a></code></p>
       <li data-md="">
-       <p>For each <var>observation</var> in <var>observer</var>.<code class="idl"><a data-link-type="idl" href="#dom-resizeobserver-observationtargets" id="ref-for-dom-resizeobserver-observationtargets-6">observationTargets</a></code> run this step:</p>
+       <p>For each <var>observation</var> in <var>observer</var>.<code class="idl"><a data-link-type="idl" href="#dom-resizeobserver-observationtargets" id="ref-for-dom-resizeobserver-observationtargets⑤">observationTargets</a></code> run this step:</p>
        <ol>
         <li data-md="">
-         <p>If <var>observation</var>.<code class="idl"><a data-link-type="idl" href="#dom-resizeobservation-isactive" id="ref-for-dom-resizeobservation-isactive-2">isActive()</a></code> is true</p>
+         <p>If <var>observation</var>.<code class="idl"><a data-link-type="idl" href="#dom-resizeobservation-isactive" id="ref-for-dom-resizeobservation-isactive①">isActive()</a></code> is true</p>
          <ol>
           <li data-md="">
-           <p>Let <var>targetDepth</var> be result of <a data-link-type="dfn" href="#calculate-depth-for-node" id="ref-for-calculate-depth-for-node-1">calculate depth for node</a> for <var>observation</var>.<code class="idl"><a data-link-type="idl" href="#dom-resizeobservation-target" id="ref-for-dom-resizeobservation-target-9">target</a></code>.</p>
+           <p>Let <var>targetDepth</var> be result of <a data-link-type="dfn" href="#calculate-depth-for-node" id="ref-for-calculate-depth-for-node">calculate depth for node</a> for <var>observation</var>.<code class="idl"><a data-link-type="idl" href="#dom-resizeobservation-target" id="ref-for-dom-resizeobservation-target⑧">target</a></code>.</p>
           <li data-md="">
-           <p>If <var>targetDepth</var> is greater than <var>depth</var> then add <var>observation</var> to <code class="idl"><a data-link-type="idl" href="#dom-resizeobserver-activetargets" id="ref-for-dom-resizeobserver-activetargets-3">activeTargets</a></code>.</p>
+           <p>If <var>targetDepth</var> is greater than <var>depth</var> then add <var>observation</var> to <code class="idl"><a data-link-type="idl" href="#dom-resizeobserver-activetargets" id="ref-for-dom-resizeobserver-activetargets②">activeTargets</a></code>.</p>
           <li data-md="">
-           <p>Else add <var>observation</var> to <code class="idl"><a data-link-type="idl" href="#dom-resizeobserver-skippedtargets" id="ref-for-dom-resizeobserver-skippedtargets-2">skippedTargets</a></code>.</p>
+           <p>Else add <var>observation</var> to <code class="idl"><a data-link-type="idl" href="#dom-resizeobserver-skippedtargets" id="ref-for-dom-resizeobserver-skippedtargets①">skippedTargets</a></code>.</p>
          </ol>
        </ol>
      </ol>
    </ol>
    <h4 class="heading settled" data-level="3.3.2" id="has-active-observations-h"><span class="secno">3.3.2. </span><span class="content">Has active observations</span><a class="self-link" href="#has-active-observations-h"></a></h4>
-   <p>To determine if <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document">Document</a></code> <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="has-active-observations">has active observations</dfn> run these steps:</p>
+   <p>To determine if <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document①">Document</a></code> <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="has-active-observations">has active observations</dfn> run these steps:</p>
    <ol>
     <li data-md="">
-     <p>For each <var>observer</var> in <code class="idl"><a data-link-type="idl" href="#dom-document-resizeobservers" id="ref-for-dom-document-resizeobservers-3">resizeObservers</a></code> run this step:</p>
+     <p>For each <var>observer</var> in <code class="idl"><a data-link-type="idl" href="#dom-document-resizeobservers" id="ref-for-dom-document-resizeobservers②">resizeObservers</a></code> run this step:</p>
      <ol>
       <li data-md="">
-       <p>If <var>observer</var>.<code class="idl"><a data-link-type="idl" href="#dom-resizeobserver-activetargets" id="ref-for-dom-resizeobserver-activetargets-4">activeTargets</a></code> is not empty, return true.</p>
+       <p>If <var>observer</var>.<code class="idl"><a data-link-type="idl" href="#dom-resizeobserver-activetargets" id="ref-for-dom-resizeobserver-activetargets③">activeTargets</a></code> is not empty, return true.</p>
      </ol>
     <li data-md="">
      <p>return false.</p>
    </ol>
    <h4 class="heading settled" data-level="3.3.3" id="has-skipped-observations-h"><span class="secno">3.3.3. </span><span class="content">Has skipped observations</span><a class="self-link" href="#has-skipped-observations-h"></a></h4>
-   <p>To determine if <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document">Document</a></code> <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="has-skipped-observations">has skipped observations</dfn> run these steps:</p>
+   <p>To determine if <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document②">Document</a></code> <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="has-skipped-observations">has skipped observations</dfn> run these steps:</p>
    <ol>
     <li data-md="">
-     <p>For each <var>observer</var> in <code class="idl"><a data-link-type="idl" href="#dom-document-resizeobservers" id="ref-for-dom-document-resizeobservers-4">resizeObservers</a></code> run this step:</p>
+     <p>For each <var>observer</var> in <code class="idl"><a data-link-type="idl" href="#dom-document-resizeobservers" id="ref-for-dom-document-resizeobservers③">resizeObservers</a></code> run this step:</p>
      <ol>
       <li data-md="">
-       <p>If <var>observer</var>.<code class="idl"><a data-link-type="idl" href="#dom-resizeobserver-skippedtargets" id="ref-for-dom-resizeobserver-skippedtargets-3">skippedTargets</a></code> is not empty, return true.</p>
+       <p>If <var>observer</var>.<code class="idl"><a data-link-type="idl" href="#dom-resizeobserver-skippedtargets" id="ref-for-dom-resizeobserver-skippedtargets②">skippedTargets</a></code> is not empty, return true.</p>
      </ol>
     <li data-md="">
      <p>return false.</p>
@@ -700,32 +691,32 @@ run these steps:</p>
     <li data-md="">
      <p>Let <var>shallowestTargetDepth</var> be ∞</p>
     <li data-md="">
-     <p>For each <var>observer</var> in <var>document</var>.<code class="idl"><a data-link-type="idl" href="#dom-document-resizeobservers" id="ref-for-dom-document-resizeobservers-5">resizeObservers</a></code> run these steps:</p>
+     <p>For each <var>observer</var> in <var>document</var>.<code class="idl"><a data-link-type="idl" href="#dom-document-resizeobservers" id="ref-for-dom-document-resizeobservers④">resizeObservers</a></code> run these steps:</p>
      <ol>
       <li data-md="">
-       <p>If <var>observer</var>.<code class="idl"><a data-link-type="idl" href="#dom-resizeobserver-activetargets" id="ref-for-dom-resizeobserver-activetargets-5">activeTargets</a></code> slot is empty, continue.</p>
+       <p>If <var>observer</var>.<code class="idl"><a data-link-type="idl" href="#dom-resizeobserver-activetargets" id="ref-for-dom-resizeobserver-activetargets④">activeTargets</a></code> slot is empty, continue.</p>
       <li data-md="">
-       <p>Let <var>entries</var> be an empty list of <code class="idl"><a data-link-type="idl" href="#resizeobserverentry" id="ref-for-resizeobserverentry-3">ResizeObserverEntry</a></code>ies.</p>
+       <p>Let <var>entries</var> be an empty list of <code class="idl"><a data-link-type="idl" href="#resizeobserverentry" id="ref-for-resizeobserverentry②">ResizeObserverEntry</a></code>ies.</p>
       <li data-md="">
-       <p>For each <var>observation</var> in <code class="idl"><a data-link-type="idl" href="#dom-resizeobserver-activetargets" id="ref-for-dom-resizeobserver-activetargets-6">activeTargets</a></code> perform these steps:</p>
+       <p>For each <var>observation</var> in <code class="idl"><a data-link-type="idl" href="#dom-resizeobserver-activetargets" id="ref-for-dom-resizeobserver-activetargets⑤">activeTargets</a></code> perform these steps:</p>
        <ol>
         <li data-md="">
-         <p>Let <var>entry</var> be new <code class="idl"><a data-link-type="idl" href="#resizeobserverentry" id="ref-for-resizeobserverentry-4">ResizeObserverEntry</a></code>(<var>observation</var>.target)</p>
+         <p>Let <var>entry</var> be new <code class="idl"><a data-link-type="idl" href="#resizeobserverentry" id="ref-for-resizeobserverentry③">ResizeObserverEntry</a></code>(<var>observation</var>.target)</p>
         <li data-md="">
          <p>Add <var>entry</var> to <var>entries</var></p>
         <li data-md="">
-         <p>Set <var>observation</var>.<code class="idl"><a data-link-type="idl" href="#dom-resizeobservation-broadcastwidth" id="ref-for-dom-resizeobservation-broadcastwidth-5">broadcastWidth</a></code> to <var>entry</var>.contentRect.width.</p>
+         <p>Set <var>observation</var>.<code class="idl"><a data-link-type="idl" href="#dom-resizeobservation-broadcastwidth" id="ref-for-dom-resizeobservation-broadcastwidth④">broadcastWidth</a></code> to <var>entry</var>.contentRect.width.</p>
         <li data-md="">
-         <p>Set <var>observation</var>.<code class="idl"><a data-link-type="idl" href="#dom-resizeobservation-broadcastheight" id="ref-for-dom-resizeobservation-broadcastheight-5">broadcastHeight</a></code> to <var>entry</var>.contentRect.height.</p>
+         <p>Set <var>observation</var>.<code class="idl"><a data-link-type="idl" href="#dom-resizeobservation-broadcastheight" id="ref-for-dom-resizeobservation-broadcastheight④">broadcastHeight</a></code> to <var>entry</var>.contentRect.height.</p>
         <li data-md="">
-         <p>Set <var>targetDepth</var> to the result of <a data-link-type="dfn" href="#calculate-depth-for-node" id="ref-for-calculate-depth-for-node-2">calculate depth for node</a> for <var>observation</var>.<code class="idl"><a data-link-type="idl" href="#dom-resizeobservation-target" id="ref-for-dom-resizeobservation-target-10">target</a></code>.</p>
+         <p>Set <var>targetDepth</var> to the result of <a data-link-type="dfn" href="#calculate-depth-for-node" id="ref-for-calculate-depth-for-node①">calculate depth for node</a> for <var>observation</var>.<code class="idl"><a data-link-type="idl" href="#dom-resizeobservation-target" id="ref-for-dom-resizeobservation-target⑨">target</a></code>.</p>
         <li data-md="">
          <p>Set <var>shallowestTargetDepth</var> to <var>targetDepth</var> if <var>targetDepth</var> &lt; <var>shallowestTargetDepth</var></p>
        </ol>
       <li data-md="">
-       <p>Invoke <var>observer</var>.<code class="idl"><a data-link-type="idl" href="#dom-resizeobserver-callback" id="ref-for-dom-resizeobserver-callback-2">callback</a></code> with <var>entries</var>.</p>
+       <p>Invoke <var>observer</var>.<code class="idl"><a data-link-type="idl" href="#dom-resizeobserver-callback" id="ref-for-dom-resizeobserver-callback①">callback</a></code> with <var>entries</var>.</p>
       <li data-md="">
-       <p>Clear <var>observer</var>.<code class="idl"><a data-link-type="idl" href="#dom-resizeobserver-activetargets" id="ref-for-dom-resizeobserver-activetargets-7">activeTargets</a></code>.</p>
+       <p>Clear <var>observer</var>.<code class="idl"><a data-link-type="idl" href="#dom-resizeobserver-activetargets" id="ref-for-dom-resizeobserver-activetargets⑥">activeTargets</a></code>.</p>
      </ol>
     <li data-md="">
      <p>Return <var>shallowestTargetDepth</var>.</p>
@@ -734,7 +725,7 @@ run these steps:</p>
    <p>To <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="deliver-resize-loop-error-notification">deliver resize loop error notification</dfn> run these steps:</p>
    <ol>
     <li data-md="">
-     <p>Create a new <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/webappapis.html#errorevent">ErrorEvent</a></code>.</p>
+     <p>Create a new <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/webappapis.html#errorevent" id="ref-for-errorevent">ErrorEvent</a></code>.</p>
     <li data-md="">
      <p>Initialize event’s message slot to "ResizeObserver loop completed with undelivered notifications.".</p>
     <li data-md="">
@@ -749,7 +740,7 @@ run these steps:</p>
      <p>Return number of nodes in <var>p</var>.</p>
    </ol>
    <h3 class="heading settled" data-level="3.4" id="lifetime"><span class="secno">3.4. </span><span class="content">ResizeObserver Lifetime</span><a class="self-link" href="#lifetime"></a></h3>
-   <p>A <code class="idl"><a data-link-type="idl" href="#resizeobserver" id="ref-for-resizeobserver-9">ResizeObserver</a></code> will remain alive until both of these conditions are met:</p>
+   <p>A <code class="idl"><a data-link-type="idl" href="#resizeobserver" id="ref-for-resizeobserver⑧">ResizeObserver</a></code> will remain alive until both of these conditions are met:</p>
    <ul>
     <li data-md="">
      <p>there are no scripting references to the observer.</p>
@@ -758,7 +749,7 @@ run these steps:</p>
    </ul>
    <h3 class="heading settled" data-level="3.5" id="integrations"><span class="secno">3.5. </span><span class="content">External Spec Integrations</span><a class="self-link" href="#integrations"></a></h3>
    <h4 class="heading settled" data-level="3.5.1" id="html-event-loop"><span class="secno">3.5.1. </span><span class="content"> HTML Processing Model: Event Loop</span><a class="self-link" href="#html-event-loop"></a></h4>
-   <p><code class="idl"><a data-link-type="idl" href="#resizeobserver" id="ref-for-resizeobserver-10">ResizeObserver</a></code> processing happens inside the step 7.12 of the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#processing-model-8">HTML Processing Model</a> event loop.</p>
+   <p><code class="idl"><a data-link-type="idl" href="#resizeobserver" id="ref-for-resizeobserver⑨">ResizeObserver</a></code> processing happens inside the step 7.12 of the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#processing-model-8" id="ref-for-processing-model-8">HTML Processing Model</a> event loop.</p>
    <p>Step 12 is currently underspecified as:</p>
    <p><q>For each fully active Document in docs, update the rendering or user interface of that Document and its browsing context to reflect the current state.</q>.</p>
    <p>Existing step 12 can be fully specified as:</p>
@@ -771,7 +762,7 @@ run these steps:</p>
     <li data-md="">
      <p>paint</p>
    </ol>
-   <p><code class="idl"><a data-link-type="idl" href="#resizeobserver" id="ref-for-resizeobserver-11">ResizeObserver</a></code> extends step 12 with resize notifications.
+   <p><code class="idl"><a data-link-type="idl" href="#resizeobserver" id="ref-for-resizeobserver①⓪">ResizeObserver</a></code> extends step 12 with resize notifications.
 It tries to deliver all pending notifications by looping
 until no pending notifications are available. This can cause
 an infinite loop.</p>
@@ -782,7 +773,7 @@ can notify.</p>
    <p>An error is generated if notification loop completes, and there
 are undelivered notifications. Elements with undelivered notifications
 will be considered for delivery in the next loop.</p>
-   <p>Step 12 with <code class="idl"><a data-link-type="idl" href="#resizeobserver" id="ref-for-resizeobserver-12">ResizeObserver</a></code> notifications is:</p>
+   <p>Step 12 with <code class="idl"><a data-link-type="idl" href="#resizeobserver" id="ref-for-resizeobserver①①">ResizeObserver</a></code> notifications is:</p>
    <p>For each fully active Document in docs, run the following steps for that Document and its browsing contentx:</p>
    <ol>
     <li data-md="">
@@ -792,23 +783,23 @@ will be considered for delivery in the next loop.</p>
     <li data-md="">
      <p>set <var>depth</var> to 0</p>
     <li data-md="">
-     <p><a data-link-type="dfn" href="#gather-active-observations-at-depth" id="ref-for-gather-active-observations-at-depth-1">gather active observations at depth</a> <var>depth</var> for <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document">Document</a></code></p>
+     <p><a data-link-type="dfn" href="#gather-active-observations-at-depth" id="ref-for-gather-active-observations-at-depth">gather active observations at depth</a> <var>depth</var> for <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document③">Document</a></code></p>
     <li data-md="">
-     <p>repeat while (document <a data-link-type="dfn" href="#has-active-observations" id="ref-for-has-active-observations-1">has active observations</a>)</p>
+     <p>repeat while (document <a data-link-type="dfn" href="#has-active-observations" id="ref-for-has-active-observations">has active observations</a>)</p>
      <ol start="2">
       <li data-md="">
-       <p>set <var>depth</var> to <a data-link-type="dfn" href="#broadcast-active-observations" id="ref-for-broadcast-active-observations-2">broadcast active observations</a></p>
+       <p>set <var>depth</var> to <a data-link-type="dfn" href="#broadcast-active-observations" id="ref-for-broadcast-active-observations①">broadcast active observations</a></p>
       <li data-md="">
        <p>recalc styles</p>
       <li data-md="">
        <p>update layout</p>
       <li data-md="">
-       <p><a data-link-type="dfn" href="#gather-active-observations-at-depth" id="ref-for-gather-active-observations-at-depth-2">gather active observations at depth</a> <var>depth</var> for <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document">Document</a></code></p>
+       <p><a data-link-type="dfn" href="#gather-active-observations-at-depth" id="ref-for-gather-active-observations-at-depth①">gather active observations at depth</a> <var>depth</var> for <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document④">Document</a></code></p>
      </ol>
     <li data-md="">
-     <p>if <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document">Document</a></code> <a data-link-type="dfn" href="#has-skipped-observations" id="ref-for-has-skipped-observations-1">has skipped observations</a> then <a data-link-type="dfn" href="#deliver-resize-loop-error-notification" id="ref-for-deliver-resize-loop-error-notification-1">deliver resize loop error notification</a></p>
+     <p>if <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document⑤">Document</a></code> <a data-link-type="dfn" href="#has-skipped-observations" id="ref-for-has-skipped-observations">has skipped observations</a> then <a data-link-type="dfn" href="#deliver-resize-loop-error-notification" id="ref-for-deliver-resize-loop-error-notification">deliver resize loop error notification</a></p>
     <li data-md="">
-     <p>update the rendering or user interface of <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document">Document</a></code> and its browsing context to reflect the current state.</p>
+     <p>update the rendering or user interface of <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document⑥">Document</a></code> and its browsing context to reflect the current state.</p>
    </ol>
   </main>
 <script src="https://www.w3.org/scripts/TR/2016/fixup.js"></script>
@@ -843,337 +834,403 @@ will be considered for delivery in the next loop.</p>
    <li>
     target
     <ul>
-     <li><a href="#dom-resizeobserverentry-target">attribute for ResizeObserverEntry</a><span>, in §2.3</span>
      <li><a href="#dom-resizeobservation-target">attribute for ResizeObservation</a><span>, in §2.4</span>
+     <li><a href="#dom-resizeobserverentry-target">attribute for ResizeObserverEntry</a><span>, in §2.3</span>
     </ul>
    <li><a href="#dom-resizeobserver-unobserve">unobserve(target)</a><span>, in §2.1</span>
   </ul>
+  <aside class="dfn-panel" data-for="term-for-eventdef-window-resize">
+   <a href="https://drafts.csswg.org/cssom-view-1/#eventdef-window-resize">https://drafts.csswg.org/cssom-view-1/#eventdef-window-resize</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-eventdef-window-resize">1. Introduction</a> <a href="#ref-for-eventdef-window-resize①">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-document">
+   <a href="https://dom.spec.whatwg.org/#document">https://dom.spec.whatwg.org/#document</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-document">2.1. ResizeObserver interface</a>
+    <li><a href="#ref-for-document①">3.3.2. Has active observations</a>
+    <li><a href="#ref-for-document②">3.3.3. Has skipped observations</a>
+    <li><a href="#ref-for-document③">3.5.1.  HTML Processing Model: Event Loop</a> <a href="#ref-for-document④">(2)</a> <a href="#ref-for-document⑤">(3)</a> <a href="#ref-for-document⑥">(4)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-element">
+   <a href="https://dom.spec.whatwg.org/#element">https://dom.spec.whatwg.org/#element</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-element">1. Introduction</a> <a href="#ref-for-element①">(2)</a> <a href="#ref-for-element②">(3)</a> <a href="#ref-for-element③">(4)</a> <a href="#ref-for-element④">(5)</a>
+    <li><a href="#ref-for-element⑤">2.1. ResizeObserver interface</a> <a href="#ref-for-element⑥">(2)</a> <a href="#ref-for-element⑦">(3)</a>
+    <li><a href="#ref-for-element⑧">2.3. ResizeObserverEntry</a> <a href="#ref-for-element⑨">(2)</a> <a href="#ref-for-element①⓪">(3)</a> <a href="#ref-for-element①①">(4)</a> <a href="#ref-for-element①②">(5)</a>
+    <li><a href="#ref-for-element①③">2.4. ResizeObservation</a> <a href="#ref-for-element①④">(2)</a> <a href="#ref-for-element①⑤">(3)</a> <a href="#ref-for-element①⑥">(4)</a> <a href="#ref-for-element①⑦">(5)</a>
+    <li><a href="#ref-for-element①⑧">3.2.1. content rect</a> <a href="#ref-for-element①⑨">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-mutationobserver">
+   <a href="https://dom.spec.whatwg.org/#mutationobserver">https://dom.spec.whatwg.org/#mutationobserver</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-mutationobserver">2.1. ResizeObserver interface</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-concept-document">
+   <a href="https://dom.spec.whatwg.org/#concept-document">https://dom.spec.whatwg.org/#concept-document</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-concept-document">3.1.1. Document</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-domrectreadonly">
+   <a href="https://drafts.fxtf.org/geometry-1/#domrectreadonly">https://drafts.fxtf.org/geometry-1/#domrectreadonly</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-domrectreadonly">2.3. ResizeObserverEntry</a> <a href="#ref-for-domrectreadonly①">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-errorevent">
+   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#errorevent">https://html.spec.whatwg.org/multipage/webappapis.html#errorevent</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-errorevent">3.3.5. Deliver Resize Loop Error</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-Exposed">
+   <a href="https://heycam.github.io/webidl/#Exposed">https://heycam.github.io/webidl/#Exposed</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-Exposed">2.1. ResizeObserver interface</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-idl-boolean">
+   <a href="https://heycam.github.io/webidl/#idl-boolean">https://heycam.github.io/webidl/#idl-boolean</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-idl-boolean">2.4. ResizeObservation</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-idl-float">
+   <a href="https://heycam.github.io/webidl/#idl-float">https://heycam.github.io/webidl/#idl-float</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-idl-float">2.4. ResizeObservation</a> <a href="#ref-for-idl-float①">(2)</a> <a href="#ref-for-idl-float②">(3)</a> <a href="#ref-for-idl-float③">(4)</a>
+   </ul>
+  </aside>
   <h3 class="no-num no-ref heading settled" id="index-defined-elsewhere"><span class="content">Terms defined by reference</span><a class="self-link" href="#index-defined-elsewhere"></a></h3>
   <ul class="index">
    <li>
     <a data-link-type="biblio">[cssom-view-1]</a> defines the following terms:
     <ul>
-     <li><a href="https://drafts.csswg.org/cssom-view-1/#eventdef-window-resize">resize</a>
+     <li><span class="dfn-paneled" id="term-for-eventdef-window-resize" style="color:initial">resize</span>
     </ul>
    <li>
     <a data-link-type="biblio">[DOM]</a> defines the following terms:
     <ul>
-     <li><a href="https://dom.spec.whatwg.org/#document">Document</a>
-     <li><a href="https://dom.spec.whatwg.org/#element">Element</a>
-     <li><a href="https://dom.spec.whatwg.org/#mutationobserver">MutationObserver</a>
-     <li><a href="https://dom.spec.whatwg.org/#concept-document">document</a>
+     <li><span class="dfn-paneled" id="term-for-document" style="color:initial">Document</span>
+     <li><span class="dfn-paneled" id="term-for-element" style="color:initial">Element</span>
+     <li><span class="dfn-paneled" id="term-for-mutationobserver" style="color:initial">MutationObserver</span>
+     <li><span class="dfn-paneled" id="term-for-concept-document" style="color:initial">document</span>
     </ul>
    <li>
     <a data-link-type="biblio">[geometry-1]</a> defines the following terms:
     <ul>
-     <li><a href="https://drafts.fxtf.org/geometry-1/#domrectreadonly">DOMRectReadOnly</a>
+     <li><span class="dfn-paneled" id="term-for-domrectreadonly" style="color:initial">DOMRectReadOnly</span>
     </ul>
    <li>
     <a data-link-type="biblio">[HTML]</a> defines the following terms:
     <ul>
-     <li><a href="https://html.spec.whatwg.org/multipage/webappapis.html#errorevent">ErrorEvent</a>
+     <li><span class="dfn-paneled" id="term-for-errorevent" style="color:initial">ErrorEvent</span>
     </ul>
    <li>
     <a data-link-type="biblio">[WebIDL]</a> defines the following terms:
     <ul>
-     <li><a href="https://heycam.github.io/webidl/#Exposed">Exposed</a>
-     <li><a href="https://heycam.github.io/webidl/#idl-boolean">boolean</a>
-     <li><a href="https://heycam.github.io/webidl/#idl-float">float</a>
+     <li><span class="dfn-paneled" id="term-for-Exposed" style="color:initial">Exposed</span>
+     <li><span class="dfn-paneled" id="term-for-idl-boolean" style="color:initial">boolean</span>
+     <li><span class="dfn-paneled" id="term-for-idl-float" style="color:initial">float</span>
     </ul>
   </ul>
   <h2 class="no-num no-ref heading settled" id="references"><span class="content">References</span><a class="self-link" href="#references"></a></h2>
   <h3 class="no-num no-ref heading settled" id="normative"><span class="content">Normative References</span><a class="self-link" href="#normative"></a></h3>
   <dl>
    <dt id="biblio-cssom-view-1">[CSSOM-VIEW-1]
-   <dd>Simon Pieters. <a href="https://www.w3.org/TR/cssom-view-1/">CSSOM View Module</a>. URL: <a href="https://www.w3.org/TR/cssom-view-1/">https://www.w3.org/TR/cssom-view-1/</a>
+   <dd>Simon Pieters. <a href="https://www.w3.org/TR/cssom-view-1/">CSSOM View Module</a>. 17 March 2016. WD. URL: <a href="https://www.w3.org/TR/cssom-view-1/">https://www.w3.org/TR/cssom-view-1/</a>
    <dt id="biblio-dom">[DOM]
    <dd>Anne van Kesteren. <a href="https://dom.spec.whatwg.org/">DOM Standard</a>. Living Standard. URL: <a href="https://dom.spec.whatwg.org/">https://dom.spec.whatwg.org/</a>
    <dt id="biblio-geometry-1">[GEOMETRY-1]
-   <dd>Simon Pieters; Dirk Schulze; Rik Cabanier. <a href="https://www.w3.org/TR/geometry-1/">Geometry Interfaces Module Level 1</a>. URL: <a href="https://www.w3.org/TR/geometry-1/">https://www.w3.org/TR/geometry-1/</a>
+   <dd>Simon Pieters; Dirk Schulze; Rik Cabanier. <a href="https://www.w3.org/TR/geometry-1/">Geometry Interfaces Module Level 1</a>. 25 November 2014. CR. URL: <a href="https://www.w3.org/TR/geometry-1/">https://www.w3.org/TR/geometry-1/</a>
    <dt id="biblio-html">[HTML]
    <dd>Anne van Kesteren; et al. <a href="https://html.spec.whatwg.org/multipage/">HTML Standard</a>. Living Standard. URL: <a href="https://html.spec.whatwg.org/multipage/">https://html.spec.whatwg.org/multipage/</a>
    <dt id="biblio-webidl">[WebIDL]
-   <dd>Cameron McCormack; Boris Zbarsky; Tobie Langel. <a href="https://www.w3.org/TR/WebIDL-1/">Web IDL</a>. URL: <a href="https://www.w3.org/TR/WebIDL-1/">https://www.w3.org/TR/WebIDL-1/</a>
+   <dd>Cameron McCormack; Boris Zbarsky; Tobie Langel. <a href="https://heycam.github.io/webidl/">Web IDL</a>. 15 December 2016. ED. URL: <a href="https://heycam.github.io/webidl/">https://heycam.github.io/webidl/</a>
   </dl>
   <h2 class="no-num no-ref heading settled" id="idl-index"><span class="content">IDL Index</span><a class="self-link" href="#idl-index"></a></h2>
-<pre class="idl def">[<a class="nv idl-code" data-link-type="constructor" href="#dom-resizeobserver-resizeobserver">Constructor</a>(<a class="n" data-link-type="idl-name" href="#callbackdef-resizeobservercallback">ResizeObserverCallback</a> <a class="nv" href="#dom-resizeobserver-resizeobserver-callback-callback">callback</a>),
-    <a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed">Exposed</a>=<span class="n">Window</span>]
-<span class="kt">interface</span> <a class="nv" href="#resizeobserver">ResizeObserver</a> {
-    <span class="kt">void</span> <a class="nv idl-code" data-link-type="method" href="#dom-resizeobserver-observe">observe</a>(<a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#element">Element</a> <a class="nv" href="#dom-resizeobserver-observe-target-target">target</a>);
-    <span class="kt">void</span> <a class="nv idl-code" data-link-type="method" href="#dom-resizeobserver-unobserve">unobserve</a>(<a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#element">Element</a> <a class="nv" href="#dom-resizeobserver-unobserve-target-target">target</a>);
-    <span class="kt">void</span> <a class="nv idl-code" data-link-type="method" href="#dom-resizeobserver-disconnect">disconnect</a>();
+<pre class="idl highlight def">[<a class="nv idl-code" data-link-type="constructor" href="#dom-resizeobserver-resizeobserver" id="ref-for-dom-resizeobserver-resizeobserver①">Constructor</a>(<a class="n" data-link-type="idl-name" href="#callbackdef-resizeobservercallback" id="ref-for-callbackdef-resizeobservercallback②">ResizeObserverCallback</a> <a class="nv" href="#dom-resizeobserver-resizeobserver-callback-callback"><code>callback</code></a>),
+    <a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed①">Exposed</a>=<span class="n">Window</span>]
+<span class="kt">interface</span> <a class="nv" href="#resizeobserver"><code>ResizeObserver</code></a> {
+    <span class="kt">void</span> <a class="nv idl-code" data-link-type="method" href="#dom-resizeobserver-observe" id="ref-for-dom-resizeobserver-observe①">observe</a>(<a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#element" id="ref-for-element⑥①">Element</a> <a class="nv" href="#dom-resizeobserver-observe-target-target"><code>target</code></a>);
+    <span class="kt">void</span> <a class="nv idl-code" data-link-type="method" href="#dom-resizeobserver-unobserve" id="ref-for-dom-resizeobserver-unobserve①">unobserve</a>(<a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#element" id="ref-for-element⑦①">Element</a> <a class="nv" href="#dom-resizeobserver-unobserve-target-target"><code>target</code></a>);
+    <span class="kt">void</span> <a class="nv idl-code" data-link-type="method" href="#dom-resizeobserver-disconnect" id="ref-for-dom-resizeobserver-disconnect①">disconnect</a>();
 };
 
-<span class="kt">callback</span> <a class="nv" href="#callbackdef-resizeobservercallback">ResizeObserverCallback</a> = <span class="kt">void</span> (<span class="kt">sequence</span>&lt;<a class="n" data-link-type="idl-name" href="#resizeobserverentry">ResizeObserverEntry</a>> <a class="nv" href="#dom-resizeobservercallback-entries">entries</a>, <a class="n" data-link-type="idl-name" href="#resizeobserver">ResizeObserver</a> <a class="nv" href="#dom-resizeobservercallback-observer">observer</a>)
+<span class="kt">callback</span> <a class="nv" href="#callbackdef-resizeobservercallback"><code>ResizeObserverCallback</code></a> = <span class="kt">void</span> (<span class="kt">sequence</span>&lt;<a class="n" data-link-type="idl-name" href="#resizeobserverentry" id="ref-for-resizeobserverentry④">ResizeObserverEntry</a>> <a class="nv" href="#dom-resizeobservercallback-entries"><code>entries</code></a>, <a class="n" data-link-type="idl-name" href="#resizeobserver" id="ref-for-resizeobserver①②">ResizeObserver</a> <a class="nv" href="#dom-resizeobservercallback-observer"><code>observer</code></a>);
 
-[<a class="nv idl-code" data-link-type="constructor" href="#dom-resizeobserverentry-resizeobserverentry">Constructor</a>(<a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#element">Element</a> <a class="nv" href="#dom-resizeobserverentry-resizeobserverentry-target-target">target</a>)
+[<a class="nv idl-code" data-link-type="constructor" href="#dom-resizeobserverentry-resizeobserverentry" id="ref-for-dom-resizeobserverentry-resizeobserverentry①">Constructor</a>(<a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#element" id="ref-for-element⑧①">Element</a> <a class="nv" href="#dom-resizeobserverentry-resizeobserverentry-target-target"><code>target</code></a>)
 ]
-<span class="kt">interface</span> <a class="nv" href="#resizeobserverentry">ResizeObserverEntry</a> {
-    <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#element">Element</a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="Element" href="#dom-resizeobserverentry-target">target</a>;
-    <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="https://drafts.fxtf.org/geometry-1/#domrectreadonly">DOMRectReadOnly</a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="DOMRectReadOnly" href="#dom-resizeobserverentry-contentrect">contentRect</a>;
+<span class="kt">interface</span> <a class="nv" href="#resizeobserverentry"><code>ResizeObserverEntry</code></a> {
+    <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#element" id="ref-for-element⑨①">Element</a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="Element" href="#dom-resizeobserverentry-target" id="ref-for-dom-resizeobserverentry-target②">target</a>;
+    <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="https://drafts.fxtf.org/geometry-1/#domrectreadonly" id="ref-for-domrectreadonly②">DOMRectReadOnly</a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="DOMRectReadOnly" href="#dom-resizeobserverentry-contentrect" id="ref-for-dom-resizeobserverentry-contentrect①">contentRect</a>;
 };
 
-[<a class="nv idl-code" data-link-type="constructor" href="#dom-resizeobservation-resizeobservation">Constructor</a>(<a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#element">Element</a> <a class="nv" href="#dom-resizeobservation-resizeobservation-target-target">target</a>)
+[<a class="nv idl-code" data-link-type="constructor" href="#dom-resizeobservation-resizeobservation" id="ref-for-dom-resizeobservation-resizeobservation①">Constructor</a>(<a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#element" id="ref-for-element①④①">Element</a> <a class="nv" href="#dom-resizeobservation-resizeobservation-target-target"><code>target</code></a>)
 ]
-<span class="kt">interface</span> <a class="nv" href="#resizeobservation">ResizeObservation</a> {
-    <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#element">Element</a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="Element" href="#dom-resizeobservation-target">target</a>;
-    <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-float"><span class="kt">float</span></a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="float" href="#dom-resizeobservation-broadcastwidth">broadcastWidth</a>;
-    <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-float"><span class="kt">float</span></a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="float" href="#dom-resizeobservation-broadcastheight">broadcastHeight</a>;
-    <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean"><span class="kt">boolean</span></a> <a class="nv idl-code" data-link-type="method" href="#dom-resizeobservation-isactive">isActive</a>();
+<span class="kt">interface</span> <a class="nv" href="#resizeobservation"><code>ResizeObservation</code></a> {
+    <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#element" id="ref-for-element①⑤①">Element</a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="Element" href="#dom-resizeobservation-target" id="ref-for-dom-resizeobservation-target①⓪">target</a>;
+    <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-float" id="ref-for-idl-float④"><span class="kt">float</span></a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="float" href="#dom-resizeobservation-broadcastwidth" id="ref-for-dom-resizeobservation-broadcastwidth⑤">broadcastWidth</a>;
+    <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-float" id="ref-for-idl-float①①"><span class="kt">float</span></a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="float" href="#dom-resizeobservation-broadcastheight" id="ref-for-dom-resizeobservation-broadcastheight⑤">broadcastHeight</a>;
+    <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean①"><span class="kt">boolean</span></a> <a class="nv idl-code" data-link-type="method" href="#dom-resizeobservation-isactive" id="ref-for-dom-resizeobservation-isactive②">isActive</a>();
 };
 
 </pre>
   <aside class="dfn-panel" data-for="resizeobserver">
    <b><a href="#resizeobserver">#resizeobserver</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-resizeobserver-1">2.1. ResizeObserver interface</a>
-    <li><a href="#ref-for-resizeobserver-2">2.2. ResizeObserverCallback</a> <a href="#ref-for-resizeobserver-3">(2)</a>
-    <li><a href="#ref-for-resizeobserver-4">3.1.1. Document</a>
-    <li><a href="#ref-for-resizeobserver-5">3.1.2. ResizeObserver</a> <a href="#ref-for-resizeobserver-6">(2)</a> <a href="#ref-for-resizeobserver-7">(3)</a> <a href="#ref-for-resizeobserver-8">(4)</a>
-    <li><a href="#ref-for-resizeobserver-9">3.4. ResizeObserver Lifetime</a>
-    <li><a href="#ref-for-resizeobserver-10">3.5.1.  HTML Processing Model: Event Loop</a> <a href="#ref-for-resizeobserver-11">(2)</a> <a href="#ref-for-resizeobserver-12">(3)</a>
+    <li><a href="#ref-for-resizeobserver">2.1. ResizeObserver interface</a>
+    <li><a href="#ref-for-resizeobserver①">2.2. ResizeObserverCallback</a> <a href="#ref-for-resizeobserver②">(2)</a>
+    <li><a href="#ref-for-resizeobserver③">3.1.1. Document</a>
+    <li><a href="#ref-for-resizeobserver④">3.1.2. ResizeObserver</a> <a href="#ref-for-resizeobserver⑤">(2)</a> <a href="#ref-for-resizeobserver⑥">(3)</a> <a href="#ref-for-resizeobserver⑦">(4)</a>
+    <li><a href="#ref-for-resizeobserver⑧">3.4. ResizeObserver Lifetime</a>
+    <li><a href="#ref-for-resizeobserver⑨">3.5.1.  HTML Processing Model: Event Loop</a> <a href="#ref-for-resizeobserver①⓪">(2)</a> <a href="#ref-for-resizeobserver①①">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-resizeobserver-resizeobserver">
    <b><a href="#dom-resizeobserver-resizeobserver">#dom-resizeobserver-resizeobserver</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-resizeobserver-resizeobserver-1">2.1. ResizeObserver interface</a>
+    <li><a href="#ref-for-dom-resizeobserver-resizeobserver">2.1. ResizeObserver interface</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-resizeobserver-observe">
    <b><a href="#dom-resizeobserver-observe">#dom-resizeobserver-observe</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-resizeobserver-observe-1">2.1. ResizeObserver interface</a>
+    <li><a href="#ref-for-dom-resizeobserver-observe">2.1. ResizeObserver interface</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-resizeobserver-unobserve">
    <b><a href="#dom-resizeobserver-unobserve">#dom-resizeobserver-unobserve</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-resizeobserver-unobserve-1">2.1. ResizeObserver interface</a>
+    <li><a href="#ref-for-dom-resizeobserver-unobserve">2.1. ResizeObserver interface</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-resizeobserver-disconnect">
    <b><a href="#dom-resizeobserver-disconnect">#dom-resizeobserver-disconnect</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-resizeobserver-disconnect-1">2.1. ResizeObserver interface</a>
+    <li><a href="#ref-for-dom-resizeobserver-disconnect">2.1. ResizeObserver interface</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="callbackdef-resizeobservercallback">
    <b><a href="#callbackdef-resizeobservercallback">#callbackdef-resizeobservercallback</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-callbackdef-resizeobservercallback-1">2.1. ResizeObserver interface</a>
-    <li><a href="#ref-for-callbackdef-resizeobservercallback-2">2.3. ResizeObserverEntry</a>
+    <li><a href="#ref-for-callbackdef-resizeobservercallback">2.1. ResizeObserver interface</a>
+    <li><a href="#ref-for-callbackdef-resizeobservercallback①">2.3. ResizeObserverEntry</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="resizeobserverentry">
    <b><a href="#resizeobserverentry">#resizeobserverentry</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-resizeobserverentry-1">2.2. ResizeObserverCallback</a>
-    <li><a href="#ref-for-resizeobserverentry-2">2.3. ResizeObserverEntry</a>
-    <li><a href="#ref-for-resizeobserverentry-3">3.3.4. Broadcast active observations</a> <a href="#ref-for-resizeobserverentry-4">(2)</a>
+    <li><a href="#ref-for-resizeobserverentry">2.2. ResizeObserverCallback</a>
+    <li><a href="#ref-for-resizeobserverentry①">2.3. ResizeObserverEntry</a>
+    <li><a href="#ref-for-resizeobserverentry②">3.3.4. Broadcast active observations</a> <a href="#ref-for-resizeobserverentry③">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-resizeobserverentry-target">
    <b><a href="#dom-resizeobserverentry-target">#dom-resizeobserverentry-target</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-resizeobserverentry-target-1">2.3. ResizeObserverEntry</a> <a href="#ref-for-dom-resizeobserverentry-target-2">(2)</a>
+    <li><a href="#ref-for-dom-resizeobserverentry-target">2.3. ResizeObserverEntry</a> <a href="#ref-for-dom-resizeobserverentry-target①">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-resizeobserverentry-contentrect">
    <b><a href="#dom-resizeobserverentry-contentrect">#dom-resizeobserverentry-contentrect</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-resizeobserverentry-contentrect-1">2.3. ResizeObserverEntry</a>
+    <li><a href="#ref-for-dom-resizeobserverentry-contentrect">2.3. ResizeObserverEntry</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-resizeobserverentry-resizeobserverentry">
    <b><a href="#dom-resizeobserverentry-resizeobserverentry">#dom-resizeobserverentry-resizeobserverentry</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-resizeobserverentry-resizeobserverentry-1">2.3. ResizeObserverEntry</a>
+    <li><a href="#ref-for-dom-resizeobserverentry-resizeobserverentry">2.3. ResizeObserverEntry</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="resizeobservation">
    <b><a href="#resizeobservation">#resizeobservation</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-resizeobservation-1">2.1. ResizeObserver interface</a> <a href="#ref-for-resizeobservation-2">(2)</a>
-    <li><a href="#ref-for-resizeobservation-3">2.4. ResizeObservation</a>
-    <li><a href="#ref-for-resizeobservation-4">3.1.2. ResizeObserver</a> <a href="#ref-for-resizeobservation-5">(2)</a> <a href="#ref-for-resizeobservation-6">(3)</a>
+    <li><a href="#ref-for-resizeobservation">2.1. ResizeObserver interface</a> <a href="#ref-for-resizeobservation①">(2)</a>
+    <li><a href="#ref-for-resizeobservation②">2.4. ResizeObservation</a>
+    <li><a href="#ref-for-resizeobservation③">3.1.2. ResizeObserver</a> <a href="#ref-for-resizeobservation④">(2)</a> <a href="#ref-for-resizeobservation⑤">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-resizeobservation-target">
    <b><a href="#dom-resizeobservation-target">#dom-resizeobservation-target</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-resizeobservation-target-1">2.4. ResizeObservation</a> <a href="#ref-for-dom-resizeobservation-target-2">(2)</a> <a href="#ref-for-dom-resizeobservation-target-3">(3)</a> <a href="#ref-for-dom-resizeobservation-target-4">(4)</a> <a href="#ref-for-dom-resizeobservation-target-5">(5)</a> <a href="#ref-for-dom-resizeobservation-target-6">(6)</a> <a href="#ref-for-dom-resizeobservation-target-7">(7)</a> <a href="#ref-for-dom-resizeobservation-target-8">(8)</a>
-    <li><a href="#ref-for-dom-resizeobservation-target-9">3.3.1. Gather active observations at depth</a>
-    <li><a href="#ref-for-dom-resizeobservation-target-10">3.3.4. Broadcast active observations</a>
+    <li><a href="#ref-for-dom-resizeobservation-target">2.4. ResizeObservation</a> <a href="#ref-for-dom-resizeobservation-target①">(2)</a> <a href="#ref-for-dom-resizeobservation-target②">(3)</a> <a href="#ref-for-dom-resizeobservation-target③">(4)</a> <a href="#ref-for-dom-resizeobservation-target④">(5)</a> <a href="#ref-for-dom-resizeobservation-target⑤">(6)</a> <a href="#ref-for-dom-resizeobservation-target⑥">(7)</a> <a href="#ref-for-dom-resizeobservation-target⑦">(8)</a>
+    <li><a href="#ref-for-dom-resizeobservation-target⑧">3.3.1. Gather active observations at depth</a>
+    <li><a href="#ref-for-dom-resizeobservation-target⑨">3.3.4. Broadcast active observations</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-resizeobservation-broadcastwidth">
    <b><a href="#dom-resizeobservation-broadcastwidth">#dom-resizeobservation-broadcastwidth</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-resizeobservation-broadcastwidth-1">2.4. ResizeObservation</a> <a href="#ref-for-dom-resizeobservation-broadcastwidth-2">(2)</a> <a href="#ref-for-dom-resizeobservation-broadcastwidth-3">(3)</a> <a href="#ref-for-dom-resizeobservation-broadcastwidth-4">(4)</a>
-    <li><a href="#ref-for-dom-resizeobservation-broadcastwidth-5">3.3.4. Broadcast active observations</a>
+    <li><a href="#ref-for-dom-resizeobservation-broadcastwidth">2.4. ResizeObservation</a> <a href="#ref-for-dom-resizeobservation-broadcastwidth①">(2)</a> <a href="#ref-for-dom-resizeobservation-broadcastwidth②">(3)</a> <a href="#ref-for-dom-resizeobservation-broadcastwidth③">(4)</a>
+    <li><a href="#ref-for-dom-resizeobservation-broadcastwidth④">3.3.4. Broadcast active observations</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-resizeobservation-broadcastheight">
    <b><a href="#dom-resizeobservation-broadcastheight">#dom-resizeobservation-broadcastheight</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-resizeobservation-broadcastheight-1">2.4. ResizeObservation</a> <a href="#ref-for-dom-resizeobservation-broadcastheight-2">(2)</a> <a href="#ref-for-dom-resizeobservation-broadcastheight-3">(3)</a> <a href="#ref-for-dom-resizeobservation-broadcastheight-4">(4)</a>
-    <li><a href="#ref-for-dom-resizeobservation-broadcastheight-5">3.3.4. Broadcast active observations</a>
+    <li><a href="#ref-for-dom-resizeobservation-broadcastheight">2.4. ResizeObservation</a> <a href="#ref-for-dom-resizeobservation-broadcastheight①">(2)</a> <a href="#ref-for-dom-resizeobservation-broadcastheight②">(3)</a> <a href="#ref-for-dom-resizeobservation-broadcastheight③">(4)</a>
+    <li><a href="#ref-for-dom-resizeobservation-broadcastheight④">3.3.4. Broadcast active observations</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-resizeobservation-resizeobservation">
    <b><a href="#dom-resizeobservation-resizeobservation">#dom-resizeobservation-resizeobservation</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-resizeobservation-resizeobservation-1">2.4. ResizeObservation</a>
+    <li><a href="#ref-for-dom-resizeobservation-resizeobservation">2.4. ResizeObservation</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-resizeobservation-isactive">
    <b><a href="#dom-resizeobservation-isactive">#dom-resizeobservation-isactive</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-resizeobservation-isactive-1">2.4. ResizeObservation</a>
-    <li><a href="#ref-for-dom-resizeobservation-isactive-2">3.3.1. Gather active observations at depth</a>
+    <li><a href="#ref-for-dom-resizeobservation-isactive">2.4. ResizeObservation</a>
+    <li><a href="#ref-for-dom-resizeobservation-isactive①">3.3.1. Gather active observations at depth</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-document-resizeobservers">
    <b><a href="#dom-document-resizeobservers">#dom-document-resizeobservers</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-document-resizeobservers-1">2.1. ResizeObserver interface</a>
-    <li><a href="#ref-for-dom-document-resizeobservers-2">3.3.1. Gather active observations at depth</a>
-    <li><a href="#ref-for-dom-document-resizeobservers-3">3.3.2. Has active observations</a>
-    <li><a href="#ref-for-dom-document-resizeobservers-4">3.3.3. Has skipped observations</a>
-    <li><a href="#ref-for-dom-document-resizeobservers-5">3.3.4. Broadcast active observations</a>
+    <li><a href="#ref-for-dom-document-resizeobservers">2.1. ResizeObserver interface</a>
+    <li><a href="#ref-for-dom-document-resizeobservers①">3.3.1. Gather active observations at depth</a>
+    <li><a href="#ref-for-dom-document-resizeobservers②">3.3.2. Has active observations</a>
+    <li><a href="#ref-for-dom-document-resizeobservers③">3.3.3. Has skipped observations</a>
+    <li><a href="#ref-for-dom-document-resizeobservers④">3.3.4. Broadcast active observations</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-resizeobserver-callback">
    <b><a href="#dom-resizeobserver-callback">#dom-resizeobserver-callback</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-resizeobserver-callback-1">2.1. ResizeObserver interface</a>
-    <li><a href="#ref-for-dom-resizeobserver-callback-2">3.3.4. Broadcast active observations</a>
+    <li><a href="#ref-for-dom-resizeobserver-callback">2.1. ResizeObserver interface</a>
+    <li><a href="#ref-for-dom-resizeobserver-callback①">3.3.4. Broadcast active observations</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-resizeobserver-observationtargets">
    <b><a href="#dom-resizeobserver-observationtargets">#dom-resizeobserver-observationtargets</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-resizeobserver-observationtargets-1">2.1. ResizeObserver interface</a> <a href="#ref-for-dom-resizeobserver-observationtargets-2">(2)</a> <a href="#ref-for-dom-resizeobserver-observationtargets-3">(3)</a> <a href="#ref-for-dom-resizeobserver-observationtargets-4">(4)</a> <a href="#ref-for-dom-resizeobserver-observationtargets-5">(5)</a>
-    <li><a href="#ref-for-dom-resizeobserver-observationtargets-6">3.3.1. Gather active observations at depth</a>
+    <li><a href="#ref-for-dom-resizeobserver-observationtargets">2.1. ResizeObserver interface</a> <a href="#ref-for-dom-resizeobserver-observationtargets①">(2)</a> <a href="#ref-for-dom-resizeobserver-observationtargets②">(3)</a> <a href="#ref-for-dom-resizeobserver-observationtargets③">(4)</a> <a href="#ref-for-dom-resizeobserver-observationtargets④">(5)</a>
+    <li><a href="#ref-for-dom-resizeobserver-observationtargets⑤">3.3.1. Gather active observations at depth</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-resizeobserver-activetargets">
    <b><a href="#dom-resizeobserver-activetargets">#dom-resizeobserver-activetargets</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-resizeobserver-activetargets-1">2.1. ResizeObserver interface</a>
-    <li><a href="#ref-for-dom-resizeobserver-activetargets-2">3.3.1. Gather active observations at depth</a> <a href="#ref-for-dom-resizeobserver-activetargets-3">(2)</a>
-    <li><a href="#ref-for-dom-resizeobserver-activetargets-4">3.3.2. Has active observations</a>
-    <li><a href="#ref-for-dom-resizeobserver-activetargets-5">3.3.4. Broadcast active observations</a> <a href="#ref-for-dom-resizeobserver-activetargets-6">(2)</a> <a href="#ref-for-dom-resizeobserver-activetargets-7">(3)</a>
+    <li><a href="#ref-for-dom-resizeobserver-activetargets">2.1. ResizeObserver interface</a>
+    <li><a href="#ref-for-dom-resizeobserver-activetargets①">3.3.1. Gather active observations at depth</a> <a href="#ref-for-dom-resizeobserver-activetargets②">(2)</a>
+    <li><a href="#ref-for-dom-resizeobserver-activetargets③">3.3.2. Has active observations</a>
+    <li><a href="#ref-for-dom-resizeobserver-activetargets④">3.3.4. Broadcast active observations</a> <a href="#ref-for-dom-resizeobserver-activetargets⑤">(2)</a> <a href="#ref-for-dom-resizeobserver-activetargets⑥">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-resizeobserver-skippedtargets">
    <b><a href="#dom-resizeobserver-skippedtargets">#dom-resizeobserver-skippedtargets</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-resizeobserver-skippedtargets-1">3.3.1. Gather active observations at depth</a> <a href="#ref-for-dom-resizeobserver-skippedtargets-2">(2)</a>
-    <li><a href="#ref-for-dom-resizeobserver-skippedtargets-3">3.3.3. Has skipped observations</a>
+    <li><a href="#ref-for-dom-resizeobserver-skippedtargets">3.3.1. Gather active observations at depth</a> <a href="#ref-for-dom-resizeobserver-skippedtargets①">(2)</a>
+    <li><a href="#ref-for-dom-resizeobserver-skippedtargets②">3.3.3. Has skipped observations</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="content-rect">
    <b><a href="#content-rect">#content-rect</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-content-rect-1">1. Introduction</a> <a href="#ref-for-content-rect-2">(2)</a>
-    <li><a href="#ref-for-content-rect-3">2.1. ResizeObserver interface</a>
-    <li><a href="#ref-for-content-rect-4">2.3. ResizeObserverEntry</a>
+    <li><a href="#ref-for-content-rect">1. Introduction</a> <a href="#ref-for-content-rect①">(2)</a>
+    <li><a href="#ref-for-content-rect②">2.1. ResizeObserver interface</a>
+    <li><a href="#ref-for-content-rect③">2.3. ResizeObserverEntry</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="gather-active-observations-at-depth">
    <b><a href="#gather-active-observations-at-depth">#gather-active-observations-at-depth</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-gather-active-observations-at-depth-1">3.5.1.  HTML Processing Model: Event Loop</a> <a href="#ref-for-gather-active-observations-at-depth-2">(2)</a>
+    <li><a href="#ref-for-gather-active-observations-at-depth">3.5.1.  HTML Processing Model: Event Loop</a> <a href="#ref-for-gather-active-observations-at-depth①">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="has-active-observations">
    <b><a href="#has-active-observations">#has-active-observations</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-has-active-observations-1">3.5.1.  HTML Processing Model: Event Loop</a>
+    <li><a href="#ref-for-has-active-observations">3.5.1.  HTML Processing Model: Event Loop</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="has-skipped-observations">
    <b><a href="#has-skipped-observations">#has-skipped-observations</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-has-skipped-observations-1">3.5.1.  HTML Processing Model: Event Loop</a>
+    <li><a href="#ref-for-has-skipped-observations">3.5.1.  HTML Processing Model: Event Loop</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="broadcast-active-observations">
    <b><a href="#broadcast-active-observations">#broadcast-active-observations</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-broadcast-active-observations-1">2.2. ResizeObserverCallback</a>
-    <li><a href="#ref-for-broadcast-active-observations-2">3.5.1.  HTML Processing Model: Event Loop</a>
+    <li><a href="#ref-for-broadcast-active-observations">2.2. ResizeObserverCallback</a>
+    <li><a href="#ref-for-broadcast-active-observations①">3.5.1.  HTML Processing Model: Event Loop</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="deliver-resize-loop-error-notification">
    <b><a href="#deliver-resize-loop-error-notification">#deliver-resize-loop-error-notification</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-deliver-resize-loop-error-notification-1">3.5.1.  HTML Processing Model: Event Loop</a>
+    <li><a href="#ref-for-deliver-resize-loop-error-notification">3.5.1.  HTML Processing Model: Event Loop</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="calculate-depth-for-node">
    <b><a href="#calculate-depth-for-node">#calculate-depth-for-node</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-calculate-depth-for-node-1">3.3.1. Gather active observations at depth</a>
-    <li><a href="#ref-for-calculate-depth-for-node-2">3.3.4. Broadcast active observations</a>
+    <li><a href="#ref-for-calculate-depth-for-node">3.3.1. Gather active observations at depth</a>
+    <li><a href="#ref-for-calculate-depth-for-node①">3.3.4. Broadcast active observations</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */
 
-        document.body.addEventListener("click", function(e) {
-            var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-            // Find the dfn element or panel, if any, that was clicked on.
-            var el = e.target;
-            var target;
-            var hitALink = false;
-            while(el.parentElement) {
-                if(el.tagName == "A") {
-                    // Clicking on a link in a <dfn> shouldn't summon the panel
-                    hitALink = true;
-                }
-                if(el.classList.contains("dfn-paneled")) {
-                    target = "dfn";
-                    break;
-                }
-                if(el.classList.contains("dfn-panel")) {
-                    target = "dfn-panel";
-                    break;
-                }
-                el = el.parentElement;
-            }
-            if(target != "dfn-panel") {
-                // Turn off any currently "on" or "activated" panels.
-                queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-                    el.classList.remove("on");
-                    el.classList.remove("activated");
-                });
-            }
-            if(target == "dfn" && !hitALink) {
-                // open the panel
-                var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-                if(dfnPanel) {
-                    console.log(dfnPanel);
-                    dfnPanel.classList.add("on");
-                    var rect = el.getBoundingClientRect();
-                    dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-                    dfnPanel.style.top = window.scrollY + rect.top + "px";
-                    var panelRect = dfnPanel.getBoundingClientRect();
-                    var panelWidth = panelRect.right - panelRect.left;
-                    if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                        // Reposition, because the panel is overflowing
-                        dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-                    }
-                } else {
-                    console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-                }
-            } else if(target == "dfn-panel") {
-                // Switch it to "activated" state, which pins it.
-                el.classList.add("activated");
-                el.style.left = null;
-                el.style.top = null;
-            }
-
+document.body.addEventListener("click", function(e) {
+    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
+    // Find the dfn element or panel, if any, that was clicked on.
+    var el = e.target;
+    var target;
+    var hitALink = false;
+    while(el.parentElement) {
+        if(el.tagName == "A") {
+            // Clicking on a link in a <dfn> shouldn't summon the panel
+            hitALink = true;
+        }
+        if(el.classList.contains("dfn-paneled")) {
+            target = "dfn";
+            break;
+        }
+        if(el.classList.contains("dfn-panel")) {
+            target = "dfn-panel";
+            break;
+        }
+        el = el.parentElement;
+    }
+    if(target != "dfn-panel") {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
+            el.classList.remove("on");
+            el.classList.remove("activated");
         });
-        </script>
+    }
+    if(target == "dfn" && !hitALink) {
+        // open the panel
+        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
+        if(dfnPanel) {
+            dfnPanel.classList.add("on");
+            var rect = el.getBoundingClientRect();
+            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
+            dfnPanel.style.top = window.scrollY + rect.top + "px";
+            var panelRect = dfnPanel.getBoundingClientRect();
+            var panelWidth = panelRect.right - panelRect.left;
+            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
+                // Reposition, because the panel is overflowing
+                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
+            }
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
+        }
+    } else if(target == "dfn-panel") {
+        // Switch it to "activated" state, which pins it.
+        el.classList.add("activated");
+        el.style.left = null;
+        el.style.top = null;
+    }
+
+});
+</script>


### PR DESCRIPTION
The update incorporates the IDL fix made a month ago in:
https://github.com/tidoust/ResizeObserver/commit/351d5d40e7f30e26fcefdb31db5d1bc34474c1de#diff-ec9cfa5f3f35ec1f84feb2e59686c34d

Note the `gh-pages` branch should be updated as well afterwards.